### PR TITLE
Cleanup travis and coverage script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: node_js
 node_js:
   - "9"
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y curl git tar
   - curl -o factorio.tar.gz -L https://www.factorio.com/get-download/latest/headless/linux64
-  - tar -xvf factorio.tar.gz
+  - tar -xf factorio.tar.gz
   - cp -n config.json.test config.json
+  - npm install -g codecov
 script:
-  - npm run cover
+  - npm run-script ci-cover
+  - codecov -f coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "master.js",
   "scripts": {
     "test": "mocha -R spec -- \"./{,!(node_modules)/**/}*.spec.js\" || true",
-    "cover": "nyc --reporter=lcovonly npm run-script test && codecov -f coverage/lcov.info -t f7b38085-36eb-4d72-84e6-64721910171e",
+    "cover": "nyc npm run-script test",
+    "ci-cover": "nyc --reporter=lcovonly npm run-script test",
     "start": "echo Run node client.js start [instance] to start slaves && node master.js",
     "install": "node lib/npmPostinstall.js",
     "bundle-dependencies": "bundle-dependencies"
@@ -25,7 +26,6 @@
     "body-parser": "^1.18.2",
     "cli": "^1.0.1",
     "cli-interact": "^0.1.9",
-    "codecov": "^3.0.1",
     "compression": "^1.7.2",
     "cookie-parser": "^1.4.3",
     "deepmerge": "^1.5.2",


### PR DESCRIPTION
Do not install git, tar and curl as these packages are installed by
default on Travis CI.  Move the codecov upload to the travis script and
do not include the codecov token as it's not needed when uploaded from
Travis CI.  Make the cover npm script into something that can be runned
locally and move the Travis CI version to a new ci-cover script.  Remove
the verbose flag from the tar extration of the factorio headless server.

<hr>

Removing the codecov token is needed, otherwise the travis linked to my fork would upload to this repos codecov.  I also want to be able to run the coverage script locally without it uploading the report (as the codecov uploader doesn't properly handle commits not uploaded or local modifications to the worktree.)