### PR TITLE
Fix master socket.io broken by a3fc1dd

### DIFF
--- a/master.js
+++ b/master.js
@@ -945,6 +945,7 @@ async function startServer() {
 	if (httpPort) {
 		let httpServer = require("http").Server(app);
 		await listen(httpServer, httpPort);
+		io.attach(httpServer);
 		console.log("Listening for HTTP on port %s...", httpServer.address().port);
 	}
 
@@ -965,6 +966,10 @@ async function startServer() {
 			cert: certificate
 		}, app)
 		await listen(httpsServer, httpsPort);
+
+		// XXX I'm uncertain whether or not socket.io actually supports
+		// attaching to multiple servers at the same time.
+		io.attach(httpsServer);
 		console.log("Listening for HTTPS on port %s...", httpsServer.address().port);
 	}
 }


### PR DESCRIPTION
Add missing attach calls to the master socket.io object that was accidentally removed by the refactoring in #204 by a3fc1dd.  Unfortunately I've been unable to determine if socket.io actually supports listening on multiple servers at the same time, this needs further investigation.