### PR TITLE
Duck tape researchsync tests

### DIFF
--- a/client.js
+++ b/client.js
@@ -587,6 +587,7 @@ async function instanceManagement(instanceconfig) {
 	for(let i = 0; i < pluginsToLoad.length; i++){
 		let pluginLoadStarted = Date.now();
 		let combinedConfig = deepmerge(instanceconfig,config,{clone:true});
+		combinedConfig.instanceName = instance;
 		let pluginConfig = pluginsToLoad[i];
 		
 		if(!global.subscribedFiles) {

--- a/sharedPlugins/researchSync/index.js
+++ b/sharedPlugins/researchSync/index.js
@@ -22,8 +22,7 @@ class ResearchSync {
         this.log_folder = './logs'
         if (!fs.existsSync(this.log_folder))
             fs.mkdirSync(this.log_folder);
-        this.log_file = path.join(this.log_folder, `${this.config.unique}-research.log`)
-        this.get_node_name_and_move_log()
+        this.log_file = path.join(this.log_folder, `${this.config.instanceName}-research.log`)
 
         this.research = {}
         this.prev_research = {}
@@ -48,30 +47,6 @@ class ResearchSync {
         } catch (e) {
             console.error(e)
         }
-    }
-
-    get_node_name_and_move_log() {
-        const url = `${this.config.masterIP}:${this.config.masterPort}/api/slaves`
-        needle.get(url, {compressed:true}, (err, res, slaves_data) => {
-            if (err)
-                return this.error(err)
-
-            slaves_data = Object.values(slaves_data)
-            let node_data = slaves_data.find(
-                slave_data => slave_data.unique === this.config.unique.toString()
-            )
-            if (node_data === undefined)
-                return this.error('slave was not found')
-            let node_name = node_data.instanceName
-            let log_file = path.join(this.log_folder, `${node_name}-research.log`)
-            if (fs.existsSync(log_file)) {
-                fs.appendFileSync(log_file, fs.readFileSync(this.log_file));
-                fs.unlinkSync(this.log_file)
-            } else {
-                fs.renameSync(this.log_file, log_file)
-            }
-            this.log_file = log_file
-        })
     }
 
     initial_request_own_data(callback) {


### PR DESCRIPTION
This is not so much about fixing research sync tests as it's to make them work at all.  I added a new entry to the instance config passed to remove one of two http requests the research sync module does in the constructor.