### PR TITLE
Add authentication to socket.io server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+Changelog
+=========
+
+Version 1.2.1
+-------------
+
+### Breaking Changes
+
+- Added authentication to the socket.io server running on the master.

--- a/client.js
+++ b/client.js
@@ -570,7 +570,10 @@ async function instanceManagement(instanceconfig) {
     console.log("Started instanceManagement();");
 
     /* Open websocket connection to master */
-	var socket = ioClient("http://"+config.masterIP+":"+config.masterPort);
+	var socket = ioClient("http://"+config.masterIP+":"+config.masterPort+"?token="+config.masterAuthToken);
+	socket.on("error", err => {
+		console.log("SOCKET | Error: ", err);
+	});
 	socket.on("hello", data => {
 		console.log("SOCKET | registering slave!");
 		socket.emit("registerSlave", {

--- a/master.js
+++ b/master.js
@@ -921,6 +921,18 @@ class wsSlave {
 	}
 }
 
+io.use((socket, next) => {
+	let token = socket.handshake.query.token;
+	authenticate.check(token).then((result) => {
+		if (result.ok) {
+			next();
+		} else {
+			console.error(`SOCKET | authentication failed for ${socket.handshake.address}`);
+			next(new Error(result.msg));
+		}
+	});
+});
+
 io.on('connection', function (socket) {
 	// cleanup dead sockets from disconnected people
 	let terminatedConnections = 0;


### PR DESCRIPTION
Authenticate connections made to the socket.io server via a token query parameter that's validated in a similar manner to the x-access-token for HTTP requests.  This is based on the [With query parameters](https://socket.io/docs/client-api/#With-query-parameters) example to socket.io.

Note that this isn't the best method of doing this as there's a risk the URL with the token in stored in web server logs.