### PR TITLE
Remove duplicated clusterTools code

### DIFF
--- a/lib/clusterTools/getInstanceName.js
+++ b/lib/clusterTools/getInstanceName.js
@@ -8,7 +8,7 @@ module.exports = function(config){
 			return new Promise((resolve, reject) => {
 				let instance = instances[instanceID];
 				if(!instance){
-					needle.get(config.masterURL + '/api/slaves', (err, response) => {
+					needle.get(config.masterURL + '/api/slaves', { compressed: true }, (err, response) => {
 						if(err || response.statusCode != 200) {
 							console.log("Unable to get JSON master/api/slaves, master might be unaccessible");
 						} else if (response && response.body) {	

--- a/sharedPlugins/clusterioMod/index.js
+++ b/sharedPlugins/clusterioMod/index.js
@@ -4,6 +4,8 @@ const fs = require("fs-extra");
 const objectOps = require("lib/objectOps.js");
 const fileOps = require("lib/fileOps");
 const stringUtils = require("lib/stringUtils.js");
+const checkHotpatchInstallation = require("lib/clusterTools/checkHotpatchInstallation");
+const getLua = require("lib/clusterTools/getLua");
 
 const pluginConfig = require("./config");
 const COMPRESS_LUA = false;
@@ -27,10 +29,10 @@ module.exports = class remoteCommands {
 		};
 		
 		(async ()=>{
-			let hotpatchInstallStatus = await this.checkHotpatchInstallation();
+			let hotpatchInstallStatus = await checkHotpatchInstallation(this.messageInterface);
 			this.messageInterface("Hotpach installation status: "+hotpatchInstallStatus);
 			if(hotpatchInstallStatus){
-				// let mainCode = await this.getSafeLua("sharedPlugins/playerManager/lua/playerTracking.lua");
+				// let mainCode = await getLua("sharedPlugins/playerManager/lua/playerTracking.lua");
 				// if(mainCode) var returnValue = await messageInterface("/silent-command remote.call('hotpatch', 'update', '"+pluginConfig.name+"', '"+pluginConfig.version+"', '"+mainCode+"')");
 			}
 		})().catch(e => console.log(e));
@@ -294,98 +296,8 @@ module.exports = class remoteCommands {
 			}
 		});
 	}
-	async getCommand(file){
-		this.commandCache = this.commandCache || {};
-		if(!this.commandCache[file]){
-			try{
-				let command = (await fs.readFile(file)).toString();
-				this.commandCache[file] = command.replace(/(\r\n\t|\n|\r\t)/gm, " "); // remove newlines
-				return this.commandCache[file];
-			} catch(e){
-				console.log("Unable to get command from file!");
-				console.log(e)
-			}
-		} else if(typeof this.commandCache[file] == "string"){
-			return this.commandCache[file];
-		} else {
-			throw new Error("Command not found");
-		}
-	}
 	async factorioOutput(data){
 		
-	}
-	getInstanceName(instanceID){
-		return new Promise((resolve, reject) => {
-			let instance = this.instances[instanceID];
-			if(!instance){
-				needle.get(this.config.masterURL + '/api/slaves', { compressed: true }, (err, response) => {
-					if(err || response.statusCode != 200) {
-						console.log("Unable to get JSON master/api/slaves, master might be unaccessible");
-					} else if (response && response.body) {	
-						if(Buffer.isBuffer(response.body)) {console.log(response.body.toString("utf-8")); throw new Error();}
-							try {
-								for (let index in response.body)
-									this.instances[index] = response.body[index].instanceName;
-							} catch (e){
-								console.log(e);
-								return null;
-							}
-						instance = this.instances[instanceID] 							
-						if (!instance) instance = instanceID;  //somehow the master doesn't know the instance	
-						resolve(instance);
-					}
-				});
-			} else {
-				resolve(instance);
-			}
-		});
-	}
-	async getSafeLua(filePath){
-		return new Promise((resolve, reject) => {
-			fs.readFile(filePath, "utf8", (err, contents) => {
-				if(err){
-					reject(err);
-				} else {
-                    // split content into lines
-					contents = contents.split(/\r?\n/);
-
-					// join those lines after making them safe again
-					contents = contents.reduce((acc, val) => {
-                        val = val.replace(/\\/g ,'\\\\');
-                        // remove leading and trailing spaces
-					    val = val.trim();
-                        // escape single quotes
-					    val = val.replace(/'/g ,'\\\'');
-
-					    // remove single line comments
-                        let singleLineCommentPosition = val.indexOf("--");
-                        let multiLineCommentPosition = val.indexOf("--[[");
-
-						if(multiLineCommentPosition === -1 && singleLineCommentPosition !== -1) {
-							val = val.substr(0, singleLineCommentPosition);
-						}
-
-                        return acc + val + '\\n';
-					}, ""); // need the "" or it will not process the first row, potentially leaving a single line comment in that disables the whole code
-
-					// console.log(contents);
-
-					// this takes about 46 ms to minify train_stop_tracking.lua in my tests on an i3
-					if(COMPRESS_LUA) contents = require("luamin").minify(contents);
-					
-					resolve(contents);
-				}
-			});
-		});
-	}
-	async checkHotpatchInstallation(){
-		let yn = await this.messageInterface("/silent-command if remote.interfaces['hotpatch'] then rcon.print('true') else rcon.print('false') end");
-		yn = yn.replace(/(\r\n\t|\n|\r\t)/gm, "");
-		if(yn == "true"){
-			return true;
-		} else if(yn == "false"){
-			return false;
-		}
 	}
 }
 async function sleep(s){

--- a/sharedPlugins/globalChat/index.js
+++ b/sharedPlugins/globalChat/index.js
@@ -6,6 +6,7 @@ module.exports = class remoteCommands {
 		this.config = mergedConfig;
 		this.socket = extras.socket;
 		this.instances = {};
+		this.getInstanceName = require("lib/clusterTools/getInstanceName")(mergedConfig);
 		
 		this.socket.on("hello", () => this.socket.emit("registerChatReciever"));
 	
@@ -50,31 +51,5 @@ module.exports = class remoteCommands {
 			});
 		}
 		}catch(e){console.log(e)}
-	}
-	getInstanceName(instanceID){
-		return new Promise((resolve, reject) => {
-			let instance = this.instances[instanceID];
-			if(!instance){
-				needle.get(this.config.masterURL + '/api/slaves', { compressed: true }, (err, response) => {
-					if(err || response.statusCode != 200) {
-						console.log("Unable to get JSON master/api/slaves, master might be unaccessible");
-					} else if (response && response.body) {	
-						if(Buffer.isBuffer(response.body)) {console.log(response.body.toString("utf-8")); throw new Error();}
-							try {
-								for (let index in response.body)
-									this.instances[index] = response.body[index].instanceName;
-							} catch (e){
-								console.log(e);
-								return null;
-							}
-						instance = this.instances[instanceID] 							
-						if (!instance) instance = instanceID;  //somehow the master doesn't know the instance	
-						resolve(instance);
-					}
-				});
-			} else {
-				resolve(instance);
-			}
-		});
 	}
 }

--- a/sharedPlugins/scenario_loader/index.js
+++ b/sharedPlugins/scenario_loader/index.js
@@ -8,7 +8,7 @@ module.exports = class remoteCommands {
 		this.config = mergedConfig;
 		
 		(async () => {
-			let hotpatchInstallStatus = await this.checkHotpatchInstallation();
+			let hotpatchInstallStatus = await clusterTools.checkHotpatchInstallation(messageInterface);
 			messageInterface("Hotpach installation status: "+hotpatchInstallStatus);
 			if(hotpatchInstallStatus){
 				await this.loadScenariosFromFolder("scenarios") // located in project root folder (with sharedMods, sharedPlugins etc)
@@ -64,15 +64,6 @@ module.exports = class remoteCommands {
 				if(returnValue) this.messageInterface(returnValue);
 				this.messageInterface(`Loaded scenario ${scenarios[i]} in ${Math.floor(Date.now()-startTime)}ms`);
 			}
-		}
-	}
-	async checkHotpatchInstallation(){
-		let yn = await this.messageInterface("/silent-command if remote.interfaces['hotpatch'] then rcon.print('true') else rcon.print('false') end");
-		yn = yn.replace(/(\r\n\t|\n|\r\t)/gm, "");
-		if(yn == "true"){
-			return true;
-		} else if(yn == "false"){
-			return false;
 		}
 	}
 }


### PR DESCRIPTION
The functions getCommand, getInstanceName, getSafeLua, and checkHotpatchInstallation are copied into plugins while also being available in lib/clusterTools.  This PR removes the plugin versions in favor of lib/clusterTools.