### PR TITLE
Add missing files to coverage report

### DIFF
--- a/lib/npmPostinstall.js
+++ b/lib/npmPostinstall.js
@@ -99,7 +99,6 @@ let downloadList = [
 ]
 
 // initiate folder creations and downloads
-processMkdirRecursive(processDownloadRecursive);
 function processMkdirRecursive(callback){
 	let item = directories.shift();
 	makeDirectory(item).then(()=>{
@@ -119,4 +118,8 @@ function processDownloadRecursive(callback){
 			processDownloadRecursive(callback);
 		}
 	});
+}
+
+if (module === require.main) {
+	processMkdirRecursive(processDownloadRecursive);
 }

--- a/sharedPlugins/UPSdisplay/test/missing.js
+++ b/sharedPlugins/UPSdisplay/test/missing.js
@@ -1,0 +1,4 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('../index');

--- a/sharedPlugins/clusterioMod/test/missing.js
+++ b/sharedPlugins/clusterioMod/test/missing.js
@@ -1,0 +1,5 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('../index');
+require('../masterPlugin');

--- a/sharedPlugins/globalChat/test/missing.js
+++ b/sharedPlugins/globalChat/test/missing.js
@@ -1,0 +1,4 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('../index');

--- a/sharedPlugins/inventoryImports/test/missing.js
+++ b/sharedPlugins/inventoryImports/test/missing.js
@@ -1,0 +1,4 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('../index');

--- a/sharedPlugins/remoteCommands/test/missing.js
+++ b/sharedPlugins/remoteCommands/test/missing.js
@@ -1,0 +1,4 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('../index');

--- a/sharedPlugins/scenario_loader/test/missing.js
+++ b/sharedPlugins/scenario_loader/test/missing.js
@@ -1,0 +1,4 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('../index');

--- a/sharedPlugins/serverManager/test/missing.js
+++ b/sharedPlugins/serverManager/test/missing.js
@@ -1,0 +1,5 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('../index');
+require('../masterPlugin');

--- a/sharedPlugins/statisticsExporter/test/missing.js
+++ b/sharedPlugins/statisticsExporter/test/missing.js
@@ -1,0 +1,5 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('../index');
+require('../masterPlugin');

--- a/test/missing.js
+++ b/test/missing.js
@@ -1,0 +1,12 @@
+// These are libraries that does not have any units test, they are
+// required here in order to track coverage for them.
+
+require('lib/clusterTools');
+require('lib/dole_nn_base');
+require('lib/getInstances');
+require('lib/hash');
+require('lib/manager/instanceManager');
+require('lib/manager/modManager');
+require('lib/manager/pluginManager');
+require('lib/npmPostinstall.js');
+require('lib/typedef');


### PR DESCRIPTION
Add missing.js test files that requires any files that currently does not have any unit tests defined for them.  This should hopefully make it so that when unit tests are added for parts of these files the coverage will increase instead of decreasing.

Note that this does not include CLI Tools/ as those are not testable.