### PR TITLE
Spawn factorio server deteached in client.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ Version 1.2.1
 
 - Updated node-factorio-api to v0.3.8 to fix mod downloads randomly breaking
   ([#229][#229].)
+- Fixed SIGINT being sent twice to Factorio server when interrupted by CTRL+C
+  on Linux ([#217][#217].)
 
+[#217]: https://github.com/clusterio/factorioClusterio/issues/217
 [#229]: https://github.com/clusterio/factorioClusterio/issues/229
 
 ### Breaking Changes

--- a/client.js
+++ b/client.js
@@ -359,7 +359,8 @@ write-data=${ path.resolve(config.instanceDirectory, instance) }\r\n
             '--rcon-port', Number(process.env.RCONPORT) || instconf.clientPort,
             '--rcon-password', instconf.clientPassword,
         ], {
-            'stdio': ['pipe', 'pipe', 'pipe']
+			'stdio': ['pipe', 'pipe', 'pipe'],
+			'detached': process.platform === "linux",
         }
     );
     factorio.stdout.on("data", data => {
@@ -471,7 +472,8 @@ write-data=${ path.resolve(config.instanceDirectory, instance) }\r\n
 				'--server-settings', instancedirectory + '/server-settings.json',
 				'--port', args.port || Number(process.env.FACTORIOPORT) || instanceconfig.factorioPort
 			], {
-				'stdio': ['pipe', 'pipe', 'pipe']
+				'stdio': ['pipe', 'pipe', 'pipe'],
+				'detached': process.platform === "linux",
 			}
 		);
 


### PR DESCRIPTION
Sending ^C via the terminal on Linux may cause SIGINT to be sent twice to the factorio process, causing it to exit without completing the saving.  This happens because the shell sends the interupt to all members of the process group for the job and this includes both the node client process and the factorio server process.

Avoid this situation by passing detached to spawn when the platform is Linux, which causes the process to be created with its own process group and therefore not targeted by a SIGINT from the shell.

This unfortunately does not work on Windows as we can't send SIGINT or ^C to a process there.  Doing `subprocces.kill()` on Windows terminates the process similarly to how SIGKILL works on Linux.

<hr>

Fixes #217 