### PR TITLE
Fix installation and instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "9"
+  - 10
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y curl git tar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Version 1.2.2
   on node v10.
 - Reordered install instructions to avoid problem with npm creating files owned
   by root in the home directory.
+- Swapped curl out with wget in the install instructions as the latter comes
+  pre-installed on Ubuntu.
 
 
 Version 1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Version 1.2.2
 - Swapped curl out with wget in the install instructions as the latter comes
   pre-installed on Ubuntu.
 
+### Breaking Changes
+
+- Node.js versions below 10 are no longer supported.
+
 
 Version 1.2.1
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Version 1.2.2
   nodes.
 - Fixed install failing due to bcrypt version less than 3 not being supported
   on node v10.
+- Reordered install instructions to avoid problem with npm creating files owned
+  by root in the home directory.
 
 
 Version 1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Version 1.2.2
   to the current one in researchSync.
 - Fixed crash in researchSync when modded technologies are present only on some
   nodes.
+- Fixed install failing due to bcrypt version less than 3 not being supported
+  on node v10.
 
 
 Version 1.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.11.2
+FROM node:10
 RUN apt-get update && apt install git curl tar -y
 RUN mkdir factorioClusterio
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ NodeJS does not support EOL ubuntu releases. Make sure you are on the most recen
 
 Master and all slaves:
 
-    sudo curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
-    sudo apt install -y nodejs python-dev git wget curl tar build-essential
+    wget -O - https://deb.nodesource.com/setup_9.x | sudo -E bash -
+    sudo apt install -y nodejs python-dev git build-essential
     git clone -b 1.2.x https://github.com/Danielv123/factorioClusterio.git
     cd factorioClusterio
-    curl -o factorio.tar.gz -L https://www.factorio.com/get-download/latest/headless/linux64
+    wget -O factorio.tar.gz https://www.factorio.com/get-download/latest/headless/linux64
     tar -xf factorio.tar.gz
     npm install --only=production
     cp config.json.dist config.json

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ Master and all slaves:
 
     sudo curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
     sudo apt install -y nodejs python-dev git wget curl tar build-essential
-    sudo npm install pm2 -g
     git clone -b 1.2.x https://github.com/Danielv123/factorioClusterio.git
     cd factorioClusterio
     curl -o factorio.tar.gz -L https://www.factorio.com/get-download/latest/headless/linux64
@@ -106,8 +105,11 @@ Master and all slaves:
     cp config.json.dist config.json
     node ./lib/npmPostinstall.js
 
+downloads and installs nodejs, git and clusterio. To specify a version, change "latest" in the link to a version number like 0.14.21.
 
-downloads and installs nodejs, pm2, git and clusterio. To specify a version, change "latest" in the link to a version number like 0.14.21.
+Optional step (if you want to use pm2):
+
+    sudo npm install pm2 -g
 
 Now you need to edit the `config.json` file. If you skip this step nothing will work.
 Pretty much all the blank fields should be filled in, except on the master where a few can be omitted.

--- a/README.md
+++ b/README.md
@@ -4,17 +4,16 @@
 <br/>
 <br/>
 
-# Warning
-
-Do not use master branch to run your Clusterio - master now is a development version and may not work
-
-Use latest stable release: https://github.com/clusterio/factorioClusterio/releases/latest
-
-Or clone latest stable branch that has name format `x.y.z`
-
 # factorioClusterio
 
 Discord for development/support/play: https://discord.gg/5XuDkje
+
+## Important notice
+
+This is the stable branch of the project.  The
+[master branch][http://github.com/clusterio/factorioClusterio/tree/master]
+is undergoing significant changes that breaks compatibility to plugins and
+existing installations and is not recommended for use.
 
 ### Ways to support me/the project:
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ NodeJS does not support EOL ubuntu releases. Make sure you are on the most recen
 
 Master and all slaves:
 
-    wget -O - https://deb.nodesource.com/setup_9.x | sudo -E bash -
+    wget -O - https://deb.nodesource.com/setup_10.x | sudo -E bash -
     sudo apt install -y nodejs python-dev git build-essential
     git clone -b 1.2.x https://github.com/Danielv123/factorioClusterio.git
     cd factorioClusterio
@@ -168,7 +168,7 @@ Game Client = The people connecting to the server
 
 **Requirements**
 
-download and install nodeJS 8 or 9 from http://nodejs.org
+download and install nodeJS 10 from http://nodejs.org
 
 download and install git from https://git-scm.com/
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "as-table": "^1.0.31",
     "averaged-timeseries": "^1.4.0",
     "base64url": "^3.0.0",
-    "bcrypt": "^2.0.1",
+    "bcrypt": "^3.0.6",
     "bcrypt-promise": "^2.0.0",
     "body-parser": "^1.18.2",
     "cli": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   ],
   "author": "Danielv123",
   "license": "MIT",
+  "engines": {
+    "node": ">=10"
+  },
   "dependencies": {
     "as-table": "^1.0.31",
     "averaged-timeseries": "^1.4.0",


### PR DESCRIPTION
Issues with bcrypt and node v9 means that the version for both it and node has to be bumped up.  I'm porting the commit I did for clusterio v2 here, but I haven't checked if the dependencies used in the 1.2.x branch support this version.  I only checked the updated dependencies would support Node.js v10 which has not been a part of the 1.2.x series, though I think bcrypt was the only one that didn't support v10.

There's also the issue with the order of the npm installations; running `sudo npm install pm2 -g` before installing anything else with npm causes it to make files in the home directory owned by root.  I've moved this step to the bottom so hopefully people will not do this.  The fix for if you accidentally do this is chown the files in $HOME/.npm and $HOME/.config/configstore back to the user (or delete them.)

Not strictly related to this is that I've swapped out curl for wget.  Ubuntu comes pre-installed with wget and the instructions told you to install curl after it had been used in the previous command (also tar can be assumed to be installed).

While at this I've reworded the warning as it's kind of confusing.  This is the right branch to install, and following these instruction is the right thing to do.  I will submit a separate PR to make the master branch instruction install the master branch version and add a more obvious warning that installing the master branch is not recommended.