### PR TITLE
Ease installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ Pretty much all the blank fields should be filled in, except on the master where
 
 **Master**
 
+    node master.js
+
+Or with pm2 (it's recommened to run it without pm2 first):
+
     pm2 start master.js --name master
 
-OR
-
-    node master.js
 
 **Server Host**
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ NodeJS does not support EOL ubuntu releases. Make sure you are on the most recen
 
 Master and all slaves:
 
-    wget -O - https://deb.nodesource.com/setup_10.x | sudo -E bash -
+    wget -qO - https://deb.nodesource.com/setup_10.x | sudo -E bash -
     sudo apt install -y nodejs python-dev git build-essential
     git clone -b 1.2.x https://github.com/Danielv123/factorioClusterio.git
     cd factorioClusterio

--- a/client.js
+++ b/client.js
@@ -53,6 +53,8 @@ if(!config.masterAuthToken || typeof config.masterAuthToken !== "string"){
 	console.error("Master server now needs an access token for write operations. As clusterio slaves depends \
 	upon this, please add your token to config.json in the field named masterAuthToken. \
 	You can retrieve your auth token from the master in secret-api-token.txt after running it once.");
+	process.exitCode = 1;
+	return;
 }
 const needleOptionsWithTokenAuthHeader = {
 	compressed:true,

--- a/config.json.dist
+++ b/config.json.dist
@@ -14,7 +14,7 @@
 	"masterPort": 8080,
 	
 	"__commentsslPort": "HTTPS port for the master to listen to. Set to 0 or an empty string to not listen for HTTPS.",
-	"sslPort": 443,
+	"sslPort": 0,
 	"sslCert": "database/certificates/cert.crt",
 	"sslPrivKey": "database/certificates/cert.key",
 	


### PR DESCRIPTION
These are some targeted changes to make installation easier.  I tried installing clusterio on a clean install of Ubuntu Desktop 18.04 and the problems I ran into were -q missing from wget line making the sudo password prompt difficult to see, listening on 443 requiring elevated privileges (ssl is broken, no point having it enabled by default), pm2 being confusing and restarting the master over and over when there's an error at startup, and forgetting to put in the masterAuthToken which the client warns about but the message quickly drowns in other log output.