### PR TITLE
Fix JSON payload limit being too low (1.2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version 1.2.3
 - Disabled uploading mods to the master server by default as this is mostly
   just a waste of bandwidth with the mod portal being integrated into the
   game now.
+- Fixed researchSync breaking with heavily modded games due to the tech tree
+  exceeding the default 100kb limit on JSON payloads.
 
 
 Version 1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 1.2.3
+-------------
+
+- Disabled uploading mods to the master server by default as this is mostly
+  just a waste of bandwidth with the mod portal being integrated into the
+  game now.
+
+
 Version 1.2.2
 -------------
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Discord for development/support/play: https://discord.gg/5XuDkje
 ## Important notice
 
 This is the stable branch of the project.  The
-[master branch][http://github.com/clusterio/factorioClusterio/tree/master]
+[master branch](http://github.com/clusterio/factorioClusterio/tree/master)
 is undergoing significant changes that breaks compatibility to plugins and
 existing installations and is not recommended for use.
 

--- a/config.json.dist
+++ b/config.json.dist
@@ -50,7 +50,7 @@
 	"__comment6.5": "When the master is undersupplied, we have 3 different modes to 'fairly' distribute items. First to ask gets all, dole division using weird formula or experimental neural net tries to make stuff as fair as possible. Feel free to play around.",
 	"disableFairItemDistribution": false,
 	"useNeuralNetDoleDivider": true,
-	"uploadModsToMaster": true,
+	"uploadModsToMaster": false,
 	"msBetweenCommands": 10,
 	"allowRemoteCommandExecution": true,
 	"enableCrossServerShout": true,

--- a/master.js
+++ b/master.js
@@ -83,7 +83,9 @@ const fileUpload = require('express-fileupload');
 var app = express();
 
 app.use(cookieParser());
-app.use(bodyParser.json());
+app.use(bodyParser.json({
+	limit: '10mb',
+}));
 app.use(bodyParser.urlencoded({
 	parameterLimit: 100000,
 	limit: '10mb',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clusterio",
-  "version": "1.2.2",
+  "version": "1.2.3-alpha",
   "description": "Interserver communication for factorio",
   "repository": "https://github.com/Danielv123/factorioClusterio",
   "main": "master.js",


### PR DESCRIPTION
This was discovered by igmac on the `#support` channel.  In heavily modded games the tech tree sent by researchSync exceeds the default 100kb limit on JSON payloads, so the techs are never synced with the master.

I thought the PayloadToLargeError had to do with the mod uploading at first.  Since there's a mod portal integrated in the game we might as well disabled the mod uploading by default now, so that's why that is included here.