### PR TITLE
Fix desync of the mods array in Hotpatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Version 1.2.3
   character, and trying to count the non-existant quick bar slots.
 - Fixed inventoryImport never receiving the script output after the default
   mode for reading script output changed to tail mode.
+- Fixed desync caused by the mods and loaded mods arrays in Hotpatch getting
+  out of sync when plugins update their scenario mod code.  To fix existing
+  games you will need copy lib/scenarios/Hotpatch/hotpatch/mod-tools.lua
+  over the existing mod-tools.lua in the save's hotpatch folder.
 
 
 Version 1.2.2

--- a/lib/scenarios/Hotpatch/hotpatch/mod-tools.lua
+++ b/lib/scenarios/Hotpatch/hotpatch/mod-tools.lua
@@ -461,8 +461,9 @@ install_mod = function(mod_name, mod_version, mod_code, mod_files)
     local index = find_installed_mod(mod_name)
     local mod = {}
     if index then
-        -- TODO: notify about installing over top of existing mod
-        mod = global.mods[index]
+        debug_log('attempt to install mod that is already installed, reinstalling: ' .. mod_name)
+        mod = table.remove(global.mods, index)
+        table.insert(global.mods, mod)
     else
         --next free index
         table.insert(global.mods, mod)


### PR DESCRIPTION
When updating a mod Hotpatch updates the loaded_mods array but not the global.mods array.  This causes events to be sent in a different order on the client/server.  Fix by updating global.mods in install_mod.

---

This was [suggested by Chrisgbk on the Discord](https://discordapp.com/channels/450361298220351489/450361298220351491/643573187027664917).  The next version of Hotpatch will probably include this fix.