### PR TITLE
Fix bcrypt failing to install on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Version 1.2.4
 - Fixed research sync endlessly updating already researched technologies
 - Removed obsolete item/fluid statistics from clusterioMod
 - Removed per mod upload logging when config.uploadModsToMaster disabled
+- Fixed bcrypt failing to install on windows due to the new version not
+  having Windows binaries.
 
 
 Version 1.2.3

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "as-table": "^1.0.31",
     "averaged-timeseries": "^1.4.0",
     "base64url": "^3.0.0",
-    "bcrypt": "^3.0.6",
+    "bcrypt": "=3.0.6",
     "bcrypt-promise": "^2.0.0",
     "body-parser": "^1.18.2",
     "cli": "^1.0.1",


### PR DESCRIPTION
The maintainers of bcrypt have in their infinite wisdom decided to stop distributing Windows binaries.  Their inner workings remain a mystery.