### PR TITLE
Document version requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Warning: This is currently broken as a result of
 # changes done in the 2.0 refactoring.
-FROM node:10
+FROM node:12
 RUN apt-get update && apt install git curl tar -y
 RUN mkdir factorioClusterio
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ Clusterio can also do a few other neat things, such as giving you access to epoc
 **Warning**: These instructions are for the unstable master version and is not
 recommended for use, see [the 1.2.x branch][1.2.x] for how to install the stable version.
 
-NodeJS does not support EOL ubuntu releases. Make sure you are on the most recent LTS release or newer.
+Clusterio runs on Node.js v12 and up, v11.13.0+ and v10.16.0+.  Node.js itself is not
+supported on EOL Ubuntu releases so make sure you're on a recent release of Ubuntu.
 
 Master and all slaves:
 
-    wget -qO - https://deb.nodesource.com/setup_10.x | sudo -E bash -
+    wget -qO - https://deb.nodesource.com/setup_12.x | sudo -E bash -
     sudo apt install -y nodejs python-dev git build-essential
     git clone -b master https://github.com/clusterio/factorioClusterio.git
     cd factorioClusterio
@@ -159,7 +160,8 @@ Game Client = The people connecting to the server
 
 **Requirements**
 
-download and install nodeJS 10 from http://nodejs.org
+download and install nodeJS 12 from http://nodejs.org.  Clusterio runs on Node.js v12 and
+up, v11.13.0+ and v10.16.0+.
 
 download and install git from https://git-scm.com/
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,6 +16,7 @@ Contents
     - [Resolving Merge Conflicts](#resolving-merge-conflicts)
     - [Updating Your GitHub Fork](#updating-your-github-fork)
 - [Changelog](#changelog)
+- [Supported Node.js and Factorio Version](#supported-node.js-and-factorio-version)
 - [Code Style](#code-style)
     - [Indenting](#indenting)
     - [Line Length](#line-length)
@@ -153,6 +154,22 @@ There's a [Changelog](../CHANGELOG.md) in the root of the project.  If
 you make changes that are visible to users of this project you should
 add an entry to the changelog describing what has changed.  The format
 of this log should be self explanatory, please follow it carefully.
+
+
+Supported Node.js and Factorio Versions
+---------------------------------------
+
+Clusterio run on Node.js v12 and up, v11.13.0+ and v10.16.0+, make sure
+to check that the Node builtin API's and npm packages you use are
+supported on these versions.  The Travis CI tests are runned on whatever
+version of Node.js v10 is the default, which at the time of writing is
+v10.18.0.
+
+For Factorio Clusterio 2.0 aims to support version 0.17.69 and up,
+including the latest experimental release.  It's recommended that you
+use the lua API reference for 0.17.69, as there's no information on what
+version Factorio API's were introduced in.  The Travis CI tests are
+runned against latest experimental release.
 
 
 Code Style

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Danielv123",
   "license": "MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16 <11 || >= 11.13"
   },
   "dependencies": {
     "as-table": "^1.0.31",


### PR DESCRIPTION
Alternate implementation of #272 clarifying which versions of Node.js is supported including v10.  I've also changed the install instructions to install v12 by default as I don't see a reason to use an older version and this is the most recent LTS release.

The version documented is the one in which events.once was introduced.