### PR TITLE
Initial config system rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ Factorio*
 /instances
 /sharedMods
 /database
-/config.json
+/config-master.json
 /config-control.json
 /config-slave.json
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Version 2.0.0
 - Rewritten the plugin system from scratch.  Plugins now inherit from
   a base class and use the same WebSocket connection Clusterio uses to
   communicate.
+- New configuration system with support for initializing configs when needed,
+  modifying config entries using built-in commands, and updating instance
+  configuration remotely.
 
 ### Features
 
@@ -38,7 +41,6 @@ Version 2.0.0
 - Added plugins directory to the views path.  This makes it possible for
   plugins to render their own ejs views or pages in their own folders by
   using paths of the format "pluginName/path/to/page-or-view".
-- Added instanceName entry to the config passed to instance plugins.
 - Replaced the per instance copy of the shared Factorio mods with
   symlinks.  On Windows hard links are used instead due to the
   privileges requirements of symlinks.
@@ -63,16 +65,18 @@ Version 2.0.0
 - Removed factorio_version from config.  The version installed is auto
   detected and used instead.
 - Removed the playerManager specific command CLI tools/delete_player.js.
-- Creating an instance, creating a save for an instance and starting an
-  instance is now three separate commands.
+- Creating an instance, assigning it to a slave, creating a save for an
+  instance and starting an instance is now four separate commands.
 - Removed oddball limits to slaves.json size.
-- Moved slave specific configuration into its own configuration file.
+- Moved slave specific and instance specific configuration into their own
+  configuration files.
 - Removed unused binary option from plugin config.
 - Removed info and shout command from globalChat plugin
 - Removed mirrorAllChat and enableCrossServerShout configuration options for
   globalChat plugin.
 - Removed UPSdisplay plugin.  UPS statistics is exported by the statistics
   exporter plugin.
+- Master server now defaults to hosting on https on port 8443.
 
 ### Breaking Changes
 
@@ -136,6 +140,9 @@ Version 2.0.0
   concurrent commands.
 - Removed allowRemoteCommandExecution config option.  Remote commands are
   always allowed with the move to master managing slaves/instances.
+- Removed `--databaseDirectory`, `--masterPort`, and `--sslPort` command line
+  arguments from the master server.
+- Implemented a new config system that replaces the old.  Breaks all plugins.
 
 
 Version 1.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ Version 2.0.0
   disableImportsOfEverythingExceptElectricity from the master config.
 - Removed msBetweenCommands config option.  The RCON is instead limited to 5
   concurrent commands.
+- Removed allowRemoteCommandExecution config option.  Remote commands are
+  always allowed with the move to master managing slaves/instances.
 
 
 Version 1.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,8 @@ Version 2.0.0
 - Removed clusterioMod plugin specific config options logItemTransfers,
   disableFairItemDistribution useNeuralNetDoleDivider, autosaveInterval, and
   disableImportsOfEverythingExceptElectricity from the master config.
+- Removed msBetweenCommands config option.  The RCON is instead limited to 5
+  concurrent commands.
 
 
 Version 1.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,9 @@ Version 2.0.0
   its place.
 - Renamed clusterio_endpoint_hit_gauge to clusterio_http_enpoint_hits_total
 - Renamed clusterio_statistics_gauge to clusterio_instance_force_flows
+- Removed clusterioMod plugin specific config options logItemTransfers,
+  disableFairItemDistribution useNeuralNetDoleDivider, autosaveInterval, and
+  disableImportsOfEverythingExceptElectricity from the master config.
 
 
 Version 1.2.4

--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ Master and all slaves:
     wget -O factorio.tar.gz https://www.factorio.com/get-download/latest/headless/linux64
     tar -xf factorio.tar.gz
     npm install --only=production
-    cp config.json.dist config.json
-    node ./lib/npmPostinstall
 
 downloads and installs nodejs, git and clusterio. To specify a version, change "latest" in the link to a version number like 0.14.21.
 
@@ -122,12 +120,6 @@ Optional step (if you want to use pm2):
 
     sudo npm install pm2 -g
 
-Now you need to edit the `config.json` file. If you skip this step nothing will work.
-Pretty much all the blank fields should be filled in, except on the master where a few can be omitted.
-
-* You get your factorio matchmaking token from factorio.com
-
-* The `masterAuthSecret` should never be touched unless you want to invalidate everyones authentication tokens
 **Ubuntu with Docker**
 
 The Docker support for Clusterio is curently broken.  If you need it
@@ -174,7 +166,6 @@ reboot when you are done, then proceed to the next steps. *reboots matter*
         git clone -b master https://github.com/clusterio/factorioClusterio
         cd factorioClusterio
         npm install --only=production
-        copy config.json.dist config.json
 
 2. Obtain Factorio by either of these two methods:
 
@@ -195,21 +186,6 @@ reboot when you are done, then proceed to the next steps. *reboots matter*
         3. Rename the folder to "factorio"
 
 
-3. Open `config.json` with a text editor and configure as desired.
-
-4. Run `node master` to generate the athentication token into secret-api-token.txt
-
-**Server Host**
-
-1. Do step 1 and 2 of the Master section above *OR* use the same folder that was created in that section.
-
-Change `masterURL `to something like `http://203.0.113.33:8080` (provided by master server owner)
-
-Change `masterAuthToken` to the value found in `secret-api-token.txt` on the master server
-
-Repeat step 4 for more servers on one machine. You should be able to find its port by looking at the slave section on master:8080 (the web interface)
-
-
 ## Running Clusterio
 
 After following the installation instructions you can use the following
@@ -222,7 +198,7 @@ It's necessary to run the master server in order for anything to work.
 Once you've completed the setup run the following command to start it
 up:
 
-    node master
+    node master run
 
 Or with pm2 (it's recommened to run it without pm2 first):
 
@@ -234,20 +210,21 @@ Or with pm2 (it's recommened to run it without pm2 first):
 Slaves connect to the master server and are managed remotely from the
 master server.  In order for slaves to connect to the master server they
 need an authentication token from the master server.  This token is
-written to secret-api-token.txt on the master server the first time it
-is started.
+written to secret-api-token.txt on the master server when it is started
+up.
 
 To set up the configuration for a new local slave run the following.
 
-    node client create-config --name "Local" --token "<token>"
+    node client config set slave.name "Local"
+    node client config set slave.master_token "<token>"
 
 This will write a new `config-slave.json` file in the current directory
 (you can change the location with the `--config` option) with the name
 and token provided.  If you are connecting to a remote master server you
-will also need to pass the `--url <url to master server>` option.
+will also need to set the `slave.master_url` option to that url.
 
-You can edit the config of a slave with the `node client edit-config`
-command.  Use `node client edit-config --help` for more information.
+You can list the config of a slave with the `node client config list`
+command.  Use `node client config --help` for more information.
 
 Once the config is set up run the slave with
 
@@ -260,21 +237,26 @@ Instances are created, managed and started from the master server.  For
 now the only interface available is the `clusterctl` command line tool
 included in Clusterio.  You can run this tool from any slave, or the
 master server without having to set up a config, if you want to manage
-the cluster from somewhere else see `node clusterctl create-config`.
+the cluster from somewhere else you will need to set the
+`control.master_url` and `control.master_token` options with the  `node
+clusterctl control-config set` command:
 
 The basic operations to start a new instance is the following
 
-    node clusterctl create-instance --slave "Local" --name "My instance"
+    node clusterctl create-instance --name "My instance"
+    node clusterctl assign-instance --instance "My instance" --slave "Local"
     node clusterctl create-save --instance "My instance"
     node clusterctl start-instance --instance "My instance"
 
-The first line creates the files and database entries for a new
-instance.  The second line creates a new savegame for the instance.  You
-could also upload your own save to the instance directory instead.  And
-finally the third line starts the instance.
+The first line creates the instance configuration on the master server.
+The second assigns the instance to a slave which creates the instance
+directory and files needed to run the instance on the given slave.  The
+third line creates a new savegame for the instance.  You could also
+upload your own save to the instance directory instead.  And finally the
+fourth line starts the instance.
 
 There are many more commands available with clusterctl.  See
-`node clusterctl --help` for more information.
+`node clusterctl --help` for a full list of them.
 
 
 ## Plugins
@@ -284,10 +266,6 @@ Here are the known Clusterio plugins in the wild:
 3. [TrainTeleports](https://github.com/Godmave/clusterioTrainTeleports) - Allows you to teleport cargotrains between servers.
 
 ## Common problems
-
-### Cannot find module: `./config`
-
-Copy your config.json.dist to config.json and configure it.
 
 ### EACCESS [...] LISTEN 443
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,6 @@ Master and all slaves:
 
 downloads and installs nodejs, git and clusterio. To specify a version, change "latest" in the link to a version number like 0.14.21.
 
-Optional step (if you want to use pm2):
-
-    sudo npm install pm2 -g
-
 **Ubuntu with Docker**
 
 The Docker support for Clusterio is curently broken.  If you need it
@@ -199,10 +195,6 @@ Once you've completed the setup run the following command to start it
 up:
 
     node master run
-
-Or with pm2 (it's recommened to run it without pm2 first):
-
-    pm2 start master --name master
 
 
 ### Slaves

--- a/config.json.dist
+++ b/config.json.dist
@@ -29,6 +29,5 @@
 		"public": true,
 		"lan": true
 	},
-	"msBetweenCommands": 10,
 	"allowRemoteCommandExecution": true
 }

--- a/config.json.dist
+++ b/config.json.dist
@@ -29,5 +29,4 @@
 		"public": true,
 		"lan": true
 	},
-	"allowRemoteCommandExecution": true
 }

--- a/config.json.dist
+++ b/config.json.dist
@@ -29,14 +29,6 @@
 		"public": true,
 		"lan": true
 	},
-	"logItemTransfers": false,
-	"__comment6.5": "When the master is undersupplied, we have 3 different modes to 'fairly' distribute items. First to ask gets all, dole division using weird formula or experimental neural net tries to make stuff as fair as possible. Feel free to play around.",
-	"disableFairItemDistribution": false,
-	"useNeuralNetDoleDivider": true,
 	"msBetweenCommands": 10,
-	"allowRemoteCommandExecution": true,
-	"__comment7": "Autosave interval for items in the master storage in milliseconds. Defaults to one minute when set to 0 or not set.",
-	"autosaveInterval": 600000,
-	"__comment8": "This setting only affects the master. It makes every import for things that arent 'electricity' return a maximum of 0. Effectively disables teleport chests.",
-	"disableImportsOfEverythingExceptElectricity": false
+	"allowRemoteCommandExecution": true
 }

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -1,0 +1,102 @@
+Configuration System
+====================
+
+<sub>This document describes the implementation and inner working of the
+configuration system in Clusterio, and unless you're developing
+Clusterio it's probably not going to be very useful for you.</sub>
+
+Clusterio uses a group based configuration system to manage settings for
+the master server, instances, slaves, and the clusterctl utility.
+Plugins get their own config group for the master server and instances
+which they can add their own fields to.  The fields are defined early in
+the startup, and the groups and their fields for disabled plugins will
+still be created.
+
+The built-in config groups and their fields are defined in
+[/lib/config/definitions.js](lib/config/definitions.js) while plugins
+can add their own config groups to the `MasterConfigGroup` and
+`InstanceConfigGroup` properties of the `info.js` export using
+subclasses of `PluginConfigGroup`.  The plugin group has the enabled
+field pre-defined on it, and it's used to enable/disable plugins.
+
+
+Defing Fields
+-------------
+
+Fields are defined using the `define` class method on group classes
+after the groupName have been set and before the class has been
+finalized.  The `define` method takes an object as argument with the
+following properties:
+
+**type**:
+    The type of config value this field will support.  The supported
+    values are boolean, string, number, and object, and if an attept is
+    made to set the field to a value that is not of the right type it
+    will be reject unless it's a string that can be converted to the
+    right type.
+
+**name**:
+    Name of the configuration field, this is the primary way the field
+    is accessed, both in code and on the command line.  As such it
+    should follow the lower\_case\_underscore style and not contain any
+    spaces or dots.
+
+**title** (optional):
+    Text used to identify the config field in user interfaces.
+
+**description** (optional):
+    Text used to describe the config field in user interfaces.
+
+**enum** (optional):
+    Array of acceptable values this field can have.  Attempts to set a
+    value not in this array will be rejected, which makes it useful for
+    making enumareted list of choices.
+
+**optional** (optional):
+    True if this field can be set to null.  Defaults to false.
+
+**initial_value** (optional if optional is true):
+    Value this config field should take in a newly initialized config.
+    This can also be an async function returning the value to use.
+
+If the value for a field stored in on disk somehow ends up being invalid
+the field will take on the initial\_value instead when the config is
+loaded.
+
+
+Accessing Fields
+----------------
+
+On the Config instance there's two ways to access fields:  through the
+set and get methods using dot notation.  E.g.:
+
+    let value = configInstance.get("group.field");
+
+Or by getting the group first and then calling set or get on that.
+E.g.:
+
+    let value = configInstance.group("group").get("field")
+
+The set method takes an extra argument, which is the value to set the
+field to.  If the value is not valid this will throw an InvalidValue
+exception, if the group or field doesn't exist it will throw an
+InvalidField exception.
+
+
+Config Lifecycle
+----------------
+
+Values for all config fields are created when the config is initialized,
+as well as for any fields with missing values when a config is loaded.
+Once a field has a value it is never automatically removed, even if the
+field or group it was part of no longer exists.  This ensures that
+plugin configuration is not lost should the server be started up without
+the plugins that defined the configuration installed.
+
+For instance configs, they are kept on the master server and serialized
+and sent over to the relevant slaves on startup.  This makes it possible
+to edit instance configs when the slave the instance is on is offline.
+A copy is also stored in the instance directory on the slave, and this
+config will be deliverd to the master server on slave startup, which
+enables instances to be copied between clusters as long as their IDs are
+unique.

--- a/docs/developing-for-clusterio.md
+++ b/docs/developing-for-clusterio.md
@@ -260,10 +260,10 @@ section.
 There's a builtin clusterio module that provides some tools for getting
 instance info and communicating to plugins, script events to listen for
 and a Factorio remote call API.  The available interfaces is documented
-in [modules/clusterio/api.lua](modules/clusterio/api.lua).  To use this
-API from another module, require it using something along the lines of
-`local clusterio_api = require("modules/clusterio/api")`.  Make sure to
-add `clusterio` as a dependency in your module.json if you use the
+in [modules/clusterio/api.lua](../modules/clusterio/api.lua).  To use
+this API from another module, require it using something along the lines
+of `local clusterio_api = require("modules/clusterio/api")`.  Make sure
+to add `clusterio` as a dependency in your module.json if you use the
 dependency entry in it.
 
 

--- a/lib/config/classes.js
+++ b/lib/config/classes.js
@@ -1,0 +1,592 @@
+/**
+ * @file Configuration classes
+ * @author Hornwitser
+ */
+"use strict";
+
+
+/**
+ * Invalid Value exception
+ *
+ * Exception class for when invalid values are attempted to be set on a
+ * field.
+ */
+class InvalidValue extends Error { };
+
+/**
+ * Invalid Field exception
+ *
+ * Exception class for when a group or field that does not exist is
+ * attempted to be accessed.
+ */
+class InvalidField extends Error { };
+
+/**
+ * Split the given string on the first instance of separator
+ *
+ * Splits @p string on the first instance of @p separator and returns an
+ * array consisting of the string up to the separator and the string
+ * after the separator.  Returns an array with the string and an empty
+ * string if the separator is not present.
+ *
+ * @returns {Array} string split on separator.
+ */
+function splitOn(separator, string) {
+	let index = string.indexOf(separator);
+	if (index === -1) {
+		return [string, ''];
+	}
+	return [string.slice(0, index), string.slice(index + separator.length)];
+}
+
+/**
+ * Return a string describing the type of the value passed
+ *
+ * Works the same as typeof, excpet that null and array types get their
+ * own string.
+ *
+ * @param value - value to return the type of.
+ * @returns {string} basic type of the value passed.
+ */
+function basicType(value) {
+	if (value === null) { return "null"; }
+	if (value instanceof Array) { return "array"; }
+	return typeof value;
+}
+
+/**
+ * Collection of config groups
+ *
+ * Represents a collection of ConfigGroup instances that can be
+ * managed as one.
+ */
+class Config {
+	constructor() {
+		if (!this.constructor._finalized) {
+			throw new Error(`Cannot instantiate incomplete Config class ${this.constructor.name}`)
+		}
+
+		this._groups = new Map();
+		this._unknownGroups = new Map();
+	}
+
+	async init() {
+		for (let [name, GroupClass] of this.constructor._groups) {
+			if (!this._groups.has(name)) {
+				let group = new GroupClass();
+				await group.init();
+				this._groups.set(name, group);
+			}
+		}
+		this._initialized = true;
+	}
+
+	_validate(serializedConfig) {
+		if (basicType(serializedConfig) !== "object") {
+			throw new Error(`Expected object, not ${basicType(serializedConfig)} for config`);
+		}
+
+		if (basicType(serializedConfig.groups) !== "array") {
+			throw new Error(`Expected groups to be an array, not ${basicType(serializedConfig.groups)}`);
+		}
+	}
+
+	async load(serializedConfig) {
+		this._validate(serializedConfig);
+		for (let serializedGroup of serializedConfig.groups) {
+			let GroupClass = this.constructor._groups.get(serializedGroup.name);
+			if (!GroupClass) {
+				this._unknownGroups.set(serializedGroup.name, serializedGroup);
+				continue;
+			}
+
+			let group = new GroupClass();
+			await group.load(serializedGroup);
+			this._groups.set(GroupClass.groupName, group);
+		}
+
+		await this.init();
+	}
+
+	/**
+	 * Serialize the config to a plain JavaScript object
+	 */
+	serialize() {
+		let groups = [...this._unknownGroups.values()];
+		for (let group of this._groups.values()) {
+			groups.push(group.serialize());
+		}
+
+		return { groups };
+	}
+
+	/**
+	 * Update the configuration based on a serialized config
+	 *
+	 * Updates all groups in the config with groups in the serialized
+	 * config passed.
+	 */
+	update(serializedConfig) {
+		this._validate(serializedConfig);
+		for (let serializedGroup of serializedConfig.groups) {
+			let group = this._groups.get(serializedGroup.name);
+			if (group) {
+				group.update(serializedGroup);
+			} else {
+				this._unknownGroups.set(serializedGroup.name, serializedGroup);
+			}
+		}
+	}
+
+	/**
+	 * Get the value for a config field
+	 */
+	get(name) {
+		let [group, field] = splitOn('.', name);
+		return this.group(group).get(field);
+	}
+
+	/**
+	 * Set the value for a config field
+	 */
+	set(name, value) {
+		let [group, field] = splitOn('.', name);
+		return this.group(group).set(field, value);
+	}
+
+	/**
+	 * Get the config group instance with the given name
+	 */
+	group(name) {
+		if (!this._initialized) {
+			throw new Error(`${this.constructor.name} instance is uninitialized`)
+		}
+		let group = this._groups.get(name);
+		if (!group) {
+			throw new InvalidField(`No config group named '${name}'`);
+		}
+		return group;
+	}
+
+	static _initSubclass() {
+		// These properties are initialized here in order to ensure that
+		// they end up on the sub-class.
+		if (!this._initialized) {
+			this._initialized = true;
+			this._finalized = false;
+			this._groups = new Map();
+		}
+	}
+
+	/**
+	 * Mapping of group name to group class
+	 *
+	 * Returns the internal mapping of group names to group classes that
+	 * mave been registered with this config.  Note that mutating this
+	 * object will lead to unexpected behaviour.
+	 *
+	 * @returns {Map<string, GroupClass>} config groups
+	 */
+	static get groups() {
+		this._initSubclass();
+		return this._groups;
+	}
+
+	/**
+	 * Locks this Config class from adding more groups.
+	 */
+	static finalize() {
+		this._initSubclass();
+		this._finalized = true;
+	}
+
+	/**
+	 * Register a ConfigGroup with this Config
+	 *
+	 * Adds the ConfigGroup to this config as a group that will get
+	 * initialized, loaded and serialized with this config class.
+	 */
+	static registerGroup(group) {
+		this._initSubclass();
+
+		if (this._finalized) {
+			throw new Error("Cannot register group on finalized config");
+		}
+
+		if (!group._finalized) {
+			throw new Error("Group must be finalized before it can be registered");
+		}
+
+		if (this._groups.has(group.groupName)) {
+			throw new Error(`${group.groupName} has already been registered`);
+		}
+
+		this._groups.set(group.groupName, group);
+	}
+}
+
+
+/**
+ * Collection of related config entries
+ */
+class ConfigGroup {
+	/**
+	 * Creates a new config group.
+	 *
+	 * After the creation of the new config group you have to call
+	 * either .init() or .load() on it in order to fully initialize it.
+	 */
+	constructor(serializedGroup) {
+		if (!this.constructor._finalized) {
+			throw new Error(`Cannot instantiate incomplete ConfigGroup class ${this.constructor.name}`)
+		}
+
+		this._fields = new Map();
+		this._unknownFields = new Map();
+	}
+
+	/**
+	 * Initialize new config group
+	 *
+	 * Computes and assigns the initial values for all fields of the
+	 * config group.
+	 */
+	async init() {
+		for (let [name, def] of this.constructor._definitions) {
+			if (this._fields.has(name)) {
+				continue;
+			}
+
+			let value = null;
+			if (typeof def.initial_value === "function") {
+				value = await def.initial_value()
+
+			} else if (def.initial_value !== undefined) {
+				value = def.initial_value;
+			}
+
+			this._fields.set(name, value);
+		}
+	}
+
+	/**
+	 * Load from serialized group
+	 *
+	 * Loads all the values from the passed serialized version of the
+	 * group and then initializes any possible missing fields from it to
+	 * their default values.
+	 */
+	async load(serializedGroup) {
+		this.update(serializedGroup);
+		await this.init();
+	}
+
+	/**
+	 * Get value for field
+	 */
+	get(name) {
+		if (!this.constructor._definitions.has(name)) {
+			throw new InvalidField(`No field named '${name}'`);
+		}
+
+		return this._fields.get(name);
+	}
+
+	/**
+	 * Set value of field
+	 *
+	 * The field must be defined for the config group and the value is
+	 * type checked against the field definition.
+	 *
+	 * @throws {InvalidValue} if value is not allowed for the field.
+	 */
+	set(name, value) {
+		let def = this.constructor._definitions.get(name);
+		if (!def) {
+			throw new Error(`No field named '${name}'`);
+		}
+
+		// Empty strings are treates as null
+		if (value === "") {
+			value = null;
+		}
+
+		if (def.enum && !def.enum.includes(value)) {
+			throw new InvalidValue(`Expected one of [${def.enum.join(', ')}], not ${value}`);
+		}
+
+		if (basicType(value) === "string") {
+			if (def.type === "boolean") {
+				if (value === "true") { value = true; }
+				else if (value === "false") { value = false; }
+
+			} else if (def.type === "number") {
+				let numberRegExp = /^[+-]?(Infinity|\d+\.(\d+)?([eE][+-]?\d+)?|\.?\d+([eE][+-]?\d+)?)$/;
+				if (numberRegExp.test(value.trim())) {
+					value = Number.parseFloat(value);
+				}
+
+			} else if (def.type === "object" ) {
+				try {
+					value = JSON.parse(value);
+				} catch (err) {
+					throw new InvalidValue(`Error parsing value for ${name}: ${err.message}`)
+				}
+			}
+		}
+
+		if (value === null) {
+			if (!def.optional) {
+				throw new InvalidValue(`Field ${name} cannot be null`)
+			}
+
+		} else {
+			if (basicType(value) !== def.type) {
+				throw new InvalidValue(`Expected type of ${name} to be ${def.type}, not ${basicType(value)}`);
+			}
+		}
+
+		this._fields.set(name, value);
+	}
+
+	/**
+	 * Update a config group from a serialized group
+	 *
+	 * Overwrites the values of all the fields in this config group that
+	 * has a valid value in the passed serialized group with that value.
+	 */
+	update(serializedGroup) {
+		if (basicType(serializedGroup) !== "object") {
+			throw new Error(`Expected object, not ${basicType(serializedGroup)} for ConfigGroup`);
+		}
+
+		if (serializedGroup.name !== this.constructor.groupName) {
+			throw new Error(`Expected group name ${this.constructor.groupName}, not ${serializedGroup.name}`);
+		}
+
+		if (basicType(serializedGroup.fields) !== "object") {
+			throw new Error(`Expected fields to be an object, not ${basicType(serializedGroup.fields)}`);
+		}
+
+		for (let [name, value] of Object.entries(serializedGroup.fields)) {
+			let def = this.constructor._definitions.get(name);
+			if (!def) {
+				this._unknownFields.set(name, value);
+				continue;
+			}
+
+			if (def.optional) {
+				if (value !== null && basicType(value) !== def.type) {
+					continue;
+				}
+			} else {
+				if (basicType(value) !== def.type) {
+					continue;
+				}
+			}
+
+			if (def.enum && !def.enum.includes(value)) {
+				continue;
+			}
+
+			this._fields.set(name, value);
+		}
+	}
+
+	/**
+	 * Serialize the config to a plain JavaScript object
+	 */
+	serialize() {
+		let fields = {};
+		for (let [name, value] of this._fields) {
+			fields[name] = value;
+		}
+
+		for (let [name, value] of this._unknownFields) {
+			fields[name] = value;
+		}
+
+		return {
+			name: this.constructor.groupName,
+			fields,
+		};
+	}
+
+	static _initSubclass() {
+		// These properties are initialized here in order to ensure that
+		// they end up on the sub-class.
+		if (!this._initialized) {
+			this._initialized = true;
+			this._definitions = new Map();
+		}
+	}
+
+	/**
+	 * Mapping of config name to field meta data
+	 *
+	 * Returns the internal meta data for the fields of this class.
+	 * Note that mutating this object will lead to unexpected behaviour.
+	 *
+	 * @returns {Map<string, Object>} field meta data
+	 */
+	static get definitions() {
+		this._initSubclass();
+		return this._definitions;
+	}
+
+	/**
+	 * Define a new configuration field
+	 *
+	 * The following properties are supported:
+	 * - type:
+	 *     string declaring the type of the config value, supports
+	 *     boolean, string, number and object.
+	 * - name:
+	 *     Name of the configuration field.  Should follow the
+	 *     lower_case_underscore style.
+	 * - title:
+	 *     Text used to identify the config field in user interfaces.
+	 * - description:
+	 *     Text used to describe the config field in user interfaces.
+	 * - enum (optional):
+	 *     Array of all values that are acceptible.  Useful for making
+	 *     enumerated values.
+	 * - optional (optional):
+	 *     True if this field can be set to null.  Defaults to false.
+	 * - initial_value (optional):
+	 *     Value this config field should take in a newly initialized
+	 *     config.  This can also be an async function returning the
+	 *     value to use.
+	 */
+	static define(item) {
+		if (this._finalized) {
+			throw new Error(`Cannot define field for ConfigGroup class ${this.name} after it has been finalized`)
+		}
+
+		if (basicType(this.groupName) !== "string") {
+			throw new Error(`Expected ConfigGroup class ${this.name} to have the groupName property set to a string`)
+		}
+
+		this._initSubclass();
+
+		let itemKeys = Object.keys(item);
+
+		// Check for required properties
+		["name", "type"].forEach(prop => {
+			if (!itemKeys.includes(prop)) {
+				throw new Error(`${prop} is required when defining an field`);
+			}
+		})
+
+		// Validate properties
+		let validTypes = ["boolean", "string", "number", "object"];
+		Object.keys(item).forEach(key => {
+			let value = item[key];
+			let valueType = basicType(value);
+			switch (key) {
+				case "type":
+					if (!validTypes.includes(value)) {
+						throw new Error(`${value} is not a valid type`);
+					}
+					break;
+
+				case "enum":
+					if (valueType !== "array") {
+						throw new Error("enum must be an array");
+					}
+					break;
+
+				case "name":
+					if (valueType !== "string") {
+						throw new Error("name must be a string");
+					}
+					break;
+
+				case "title":
+					if (valueType !== "string") {
+						throw new Error("title must be a string");
+					}
+					break;
+
+				case "description":
+					if (valueType !== "string") {
+						throw new Error("description must be a string");
+					}
+					break;
+
+				case "optional":
+					if (valueType !== "boolean") {
+						throw new Error("optional must be a boolean");
+					}
+					break;
+
+				case "initial_value":
+					if (valueType !== item.type && valueType !== "function") {
+						throw new Error("initial_value must match the type or be a function");
+					}
+					break;
+
+				default:
+					throw new Error(`Unknown property ${key}`);
+			}
+		});
+
+		if (this._definitions.has(item.name)) {
+			throw new Error(`Config field ${item.name} has already been defined`);
+		}
+
+		let computed = Object.assign({
+			optional: false,
+			fullName: `${this.groupName}.${item.name}`,
+		}, item)
+
+		if (!computed.optional && computed.initial_value === undefined) {
+			throw new Error(`Non-optional field ${item.name} needs an initial_value`);
+		}
+
+		this._definitions.set(item.name, computed);
+	}
+
+	/**
+	 * Locks this ConfigGroup class from adding more definitons.
+	 */
+	static finalize() {
+		if (basicType(this.groupName) !== "string") {
+			throw new Error(`Expected ConfigGroup class ${this.name} to have the groupName property set to a string`)
+		}
+
+		this._initSubclass();
+		this._finalized = true;
+	}
+}
+
+/**
+ * Config group for plugins
+ *
+ * Grouping that includes per plugin fields clusterio uses to manage
+ * plugins.  This is currently only the enabled field.  It is otherwise
+ * identical to the ConfigGroup class.
+ */
+class PluginConfigGroup extends ConfigGroup {
+	static _initSubclass() {
+		if (!this._initialized) {
+			super._initSubclass();
+			this.define({
+				name: "enabled",
+				description: "Enable plugin",
+				type: "boolean",
+				initial_value: true,
+			});
+		}
+	}
+}
+
+
+module.exports = {
+	InvalidField,
+	InvalidValue,
+
+	Config,
+	ConfigGroup,
+	PluginConfigGroup,
+}

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1,0 +1,318 @@
+/**
+ * @file Core definitions for the configuration system
+ * @author Hornwitser
+ */
+"use strict";
+
+const util = require("util");
+const crypto = require("crypto");
+const path = require("path");
+const fs = require("fs-extra");
+
+const classes = require("./classes");
+
+
+class MasterGroup extends classes.ConfigGroup { }
+MasterGroup.groupName = "master"
+MasterGroup.define({
+	name: "database_directory",
+	title: "Database directory",
+	description: "Directory where item and configuration data is stored.",
+	type: "string",
+	initial_value: "database",
+});
+MasterGroup.define({
+	name: "factorio_directory",
+	description: "Path to directory to look for factorio installs",
+	type: "string",
+	initial_value: "factorio"
+});
+MasterGroup.define({
+	name: "http_port",
+	title: "HTTP Port",
+	description: "Port to listen for HTTP connections on, set to null to not listen for HTTP connections.",
+	type: "number",
+	optional: true
+});
+MasterGroup.define({
+	name: "https_port",
+	title: "HTTPS Port",
+	description: "Port to listen for HTTPS connection on, set to null to not listen for HTTPS connections.",
+	type: "number",
+	optional: true,
+	initial_value: 8443,
+});
+MasterGroup.define({
+	name: "tls_certificate",
+	title: "TLS Certificate",
+	description: "Path to the certificate to use for HTTPS.",
+	type: "string",
+	optional: true,
+	initial_value: "database/certificates/cert.crt",
+});
+MasterGroup.define({
+	name: "tls_private_key",
+	title: "TLS Private Key",
+	description: "Path to the private key to use for HTTPS.",
+	type: "string",
+	optional: true,
+	initial_value: "database/certificates/cert.key",
+});
+MasterGroup.define({
+	name: "auth_secret",
+	title: "Master Authentication Secret",
+	description:
+		"Secret used to generate and verify authentication tokens."
+		+"  Should be a long string of random letters and numbers."
+		+"  Do not share this.",
+	type: "string",
+	initial_value: async function() {
+		console.log("Generating new master authentication secret");
+		let asyncRandomBytes = util.promisify(crypto.randomBytes);
+		let bytes = await asyncRandomBytes(256);
+		return bytes.toString("base64");
+	},
+});
+MasterGroup.finalize();
+
+class MasterConfig extends classes.Config { }
+MasterConfig.registerGroup(MasterGroup);
+
+
+class SlaveGroup extends classes.ConfigGroup {}
+SlaveGroup.groupName = "slave";
+SlaveGroup.define({
+	name: "name",
+	description: "Name of the slave",
+	type: "string",
+	initial_value: "New Slave",
+});
+SlaveGroup.define({
+	name: "id",
+	description: "ID of the slave",
+	type: "number",
+	initial_value: () => Math.random() * 2**31 | 0,
+});
+SlaveGroup.define({
+	name: "factorio_directory",
+	description: "Path to directory to look for factorio installs",
+	type: "string",
+	initial_value: "factorio"
+});
+SlaveGroup.define({
+	name: "instances_directory",
+	description: "Path to directory to store instances in.",
+	type: "string",
+	initial_value: "instances",
+});
+SlaveGroup.define({
+	name: "master_url",
+	description: "URL to connect to the master server at",
+	type: "string",
+	initial_value: "https://localhost:8443/",
+});
+SlaveGroup.define({
+	name: "master_token",
+	description: "Token to authenticate to master server with.",
+	type: "string",
+	initial_value: "enter token here",
+});
+SlaveGroup.define({
+	name: "public_address",
+	description: "Public facing address players should connect to in order to join instances on this slave",
+	type: "string",
+	initial_value: "localhost",
+});
+SlaveGroup.finalize();
+
+class SlaveConfig extends classes.Config { }
+SlaveConfig.registerGroup(SlaveGroup);
+
+
+class InstanceGroup extends classes.ConfigGroup { }
+InstanceGroup.groupName = "instance"
+InstanceGroup.define({
+	name: "name",
+	type: "string",
+	initial_value: "New Instance",
+});
+InstanceGroup.define({
+	name: "id",
+	description: "ID of the slave",
+	type: "number",
+	initial_value: () => Math.random() * 2**31 | 0,
+});
+InstanceGroup.define({
+	name: "assigned_slave",
+	type: "number",
+	optional: true,
+});
+InstanceGroup.finalize();
+
+class FactorioGroup extends classes.ConfigGroup { }
+FactorioGroup.groupName = "factorio";
+FactorioGroup.define({
+	name: "game_port",
+	description: "UDP port to run game on, uses a random port if null",
+	type: "number",
+	optional: true,
+});
+FactorioGroup.define({
+	name: "rcon_port",
+	description: "TCP port to run RCON on, uses a random port if null",
+	type: "number",
+	optional: true,
+});
+FactorioGroup.define({
+	name: "rcon_password",
+	description: "Password for RCON, randomly generated if null",
+	type: "string",
+	optional: true,
+});
+FactorioGroup.define({
+	name: "settings",
+	description: "Settings overridden in server-settings.json",
+	type: "object",
+	initial_value: {
+		"tags": ["clusterio"],
+		"auto_pause": false,
+	},
+});
+FactorioGroup.finalize();
+
+class InstanceConfig extends classes.Config { }
+InstanceConfig.registerGroup(InstanceGroup);
+InstanceConfig.registerGroup(FactorioGroup);
+
+
+function validateGroup(pluginInfo, groupName) {
+	if (!pluginInfo[groupName] instanceof classes.PluginConfigGroup) {
+		throw new Error(
+			`Expected ${groupName} for ${pluginInfo.name} to be an instance of PluginConfigGroup`
+		);
+	}
+
+	if (pluginInfo[groupName].groupName !== pluginInfo.name) {
+		throw new Error(
+			`Expected ${groupName} for ${pluginInfo.name} to be named after the plugin`
+		);
+	}
+}
+
+/**
+ * Registers the config groups for the provided plugin infos
+ */
+function registerPluginConfigGroups(pluginInfos) {
+	for (let pluginInfo of pluginInfos) {
+		if (pluginInfo.MasterConfigGroup) {
+			validateGroup(pluginInfo, "MasterConfigGroup");
+			MasterConfig.registerGroup(pluginInfo.MasterConfigGroup);
+
+		} else {
+			class MasterConfigGroup extends classes.PluginConfigGroup { }
+			MasterConfigGroup.groupName = pluginInfo.name;
+			MasterConfigGroup.finalize();
+			MasterConfig.registerGroup(MasterConfigGroup);
+		}
+
+		if (pluginInfo.instanceEntrypoint) {
+			if (pluginInfo.InstanceConfigGroup) {
+				validateGroup(pluginInfo, "InstanceConfigGroup");
+				InstanceConfig.registerGroup(pluginInfo.InstanceConfigGroup);
+
+			} else {
+				class InstanceConfigGroup extends classes.PluginConfigGroup { }
+				InstanceConfigGroup.groupName = pluginInfo.name;
+				InstanceConfigGroup.finalize();
+				InstanceConfig.registerGroup(InstanceConfigGroup);
+			}
+		}
+	}
+}
+
+/**
+ * Lock configs from adding more groups and make them usable
+ */
+function finalizeConfigs() {
+	MasterConfig.finalize();
+	SlaveConfig.finalize();
+	InstanceConfig.finalize();
+}
+
+/**
+ * Yargs config command
+ *
+ * Can be passed to yargs.command to implement a config command.  Use
+ * handleConfigCommand to do the requested action.
+ */
+function configCommand(yargs) {
+	yargs
+		.command("set <field> [value]", "Set config field")
+		.command("show <field>", "Show value of the given config field")
+		.command("list", "List all configuration fields and their values")
+		.demandCommand(1, "You need to specify a command to run")
+		.strict()
+	;
+}
+
+/**
+ * Handle yargs command
+ *
+ * Handle the actions that are made available by configCommand.
+ */
+async function handleConfigCommand(args, instance, configPath) {
+	let command = args._[1];
+
+	if (command === "list") {
+		for (let GroupClass of instance.constructor.groups.values()) {
+			for (let def of GroupClass.definitions.values()) {
+				let value = instance.get(def.fullName);
+				console.log(`${def.fullName} ${JSON.stringify(value)}`);
+			}
+		}
+
+	} else if (command === "show") {
+		try {
+			console.log(instance.get(args.field));
+		} catch (err) {
+			if (err instanceof classes.InvalidField) {
+				console.error(err.message);
+			} else {
+				throw err;
+			}
+		}
+
+	} else if (command === "set") {
+		if (args.value === undefined) {
+			args.value = null;
+		}
+
+		try {
+			instance.set(args.field, args.value);
+			await fs.outputFile(configPath, JSON.stringify(instance.serialize(), null, 4));
+		} catch (err) {
+			if (err instanceof classes.InvalidField || err instanceof classes.InvalidValue) {
+				console.error(err.message);
+			} else {
+				throw err;
+			}
+		}
+	}
+}
+
+
+module.exports = {
+	MasterGroup,
+	SlaveGroup,
+	InstanceGroup,
+	FactorioGroup,
+
+	MasterConfig,
+	SlaveConfig,
+	InstanceConfig,
+
+	registerPluginConfigGroups,
+	finalizeConfigs,
+	configCommand,
+	handleConfigCommand,
+}

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,0 +1,9 @@
+/**
+ * @file Configuration System
+ * @author Hornwitser
+ */
+
+module.exports = {
+	...require("./classes"),
+	...require("./definitions"),
+}

--- a/lib/factorio/server.js
+++ b/lib/factorio/server.js
@@ -809,11 +809,10 @@ class FactorioServer extends events.EventEmitter {
 	 *
 	 * Loads server-settings.example.json from the data dir.
 	 *
-	 * @param {string} dataDir - The data directory for Factorio
 	 * @returns {object} the parsed server-settings.
 	 */
-	static async exampleSettings(dataDir) {
-		return JSON.parse(await fs.readFile(path.join(dataDir, "server-settings.example.json"), "utf-8"));
+	async exampleSettings(dataDir) {
+		return JSON.parse(await fs.readFile(this.dataPath("server-settings.example.json"), "utf-8"));
 	}
 
 	async _writeConfigIni() {

--- a/lib/link/messages.js
+++ b/lib/link/messages.js
@@ -199,11 +199,11 @@ messages.listInstances = new Request({
 			type: "array",
 			items: {
 				additionalProperties: false,
-				required: ["name", "id", "slave_id"],
+				required: ["name", "id", "assigned_slave"],
 				properties: {
 					"name": { type: "string" },
 					"id": { type: "integer" },
-					"slave_id": { type: "integer" },
+					"assigned_slave": { type: ["null", "integer"] },
 				},
 			},
 		},
@@ -221,44 +221,59 @@ messages.setInstanceOutputSubscriptions = new Request({
 	},
 });
 
-messages.createInstanceCommand = new Request({
+messages.createInstance = new Request({
 	type: 'create_instance',
 	links: ['control-master'],
 	requestProperties: {
-		"name": { type: "string" },
+		"serialized_config": { type: "object" },
+	},
+});
+
+messages.getInstanceConfig = new Request({
+	type: "get_instance_config",
+	links: ["control-master"],
+	requestProperties: {
+		"instance_id": { type: "integer" },
+	},
+	responseProperties: {
+		"serialized_config": { type: "object" },
+	},
+});
+
+messages.setInstanceConfigField = new Request({
+	type: "set_instance_config_field",
+	links: ["control-master"],
+	requestProperties: {
+		"instance_id": { type: "integer" },
+		"field": { type: "string" },
+		"value": { type: "string" },
+	},
+});
+
+messages.assignInstanceCommand = new Request({
+	type: 'assign_instance_command',
+	links: ['control-master'],
+	requestProperties: {
+		"instance_id": { type: "integer" },
 		"slave_id": { type: "integer" },
 	},
 });
 
-messages.createInstance = new Request({
-	type: 'create_instance',
+messages.assignInstance = new Request({
+	type: 'assign_instance',
 	links: ['master-slave'],
 	requestProperties: {
-		"id": { type: "integer" },
-		"options": {
-			additionalProperties: false,
-			required: [
-				"name", "description", "visibility", "username", "token", "game_password",
-				"verify_user_identity", "allow_commands", "auto_pause",
-			],
-			properties: {
-				"name": { type: "string" },
-				"description": { type: "string" },
-				"visibility": { type: "object" },
-				"username": { type: "string" },
-				"token": { type: "string" },
-				"game_password": { type: "string" },
-				"verify_user_identity": { type: "boolean" },
-				"allow_commands": { type: "string" },
-				"auto_pause": { type: "boolean" },
-			},
-		},
+		"serialized_config": { type: "object" },
 	},
-});
+	forwardTo: 'instance',
+})
 
 messages.startInstance = new Request({
 	type: 'start_instance',
 	links: ['control-master', 'master-slave', 'slave-instance'],
+	requestProperties: {
+		"instance_id": { type: "integer" },
+	},
 	forwardTo: 'instance',
 });
 
@@ -447,10 +462,9 @@ messages.updateInstances = new Event({
 			items: {
 				type: "object",
 				additionalProperties: false,
-				required: ["id", "name"],
+				required: ["serialized_config"],
 				properties: {
-					"id": { type: "integer" },
-					"name": { type: "string" },
+					"serialized_config": { type: "object" },
 				},
 			},
 		},

--- a/lib/manager/modManager.js
+++ b/lib/manager/modManager.js
@@ -19,8 +19,19 @@ const fileOps = require("lib/fileOps");
 function ellipse(str, max){
    return str.length > (max - 3) ? str.substring(0,max-3) + '...' : str;
 }
+
 // https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
-function formatBytes(a,b){if(0==a)return"0 Bytes";var c=1024,d=b||2,e=["Bytes","KB","MB","GB","TB","PB","EB","ZB","YB"],f=Math.floor(Math.log(a)/Math.log(c));return parseFloat((a/Math.pow(c,f)).toFixed(d))+" "+e[f]};
+function formatBytes(size, decimals) {
+	if (bytes === 0) return '0 Bytes';
+
+	const k = 1024;
+	const dm = decimals < 0 ? 0 : decimals;
+	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
 
 
 /**

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -106,7 +106,16 @@ class BaseMasterPlugin {
 	async onExit() { }
 }
 
-async function getPluginInfos(baseDir) {
+/**
+ * Load plugin information
+ *
+ * Searches through the plugin directory and loads each plugin's info
+ * module.  Once loaded the info modules will not be reloaded should this
+ * function be called again.
+ *
+ * @returns {Map<string, Object>} mapping of plugin name to info module.
+ */
+async function loadPluginInfos(baseDir) {
 	let plugins = [];
 	for (let pluginDir of await fs.readdir(baseDir)) {
 		let pluginInfo;
@@ -129,7 +138,6 @@ async function getPluginInfos(baseDir) {
 			);
 		}
 
-		pluginInfo.enabled = !await fs.exists(path.join(baseDir, pluginDir, "DISABLED"));
 		plugins.push(pluginInfo);
 	}
 	return plugins;
@@ -155,6 +163,6 @@ module.exports = {
 	BaseInstancePlugin,
 	BaseMasterPlugin,
 
-	getPluginInfos,
+	loadPluginInfos,
 	attachPluginMessages,
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bcrypt": "=3.0.6",
     "bcrypt-promise": "^2.0.0",
     "body-parser": "^1.18.2",
+    "chalk": "^3.0.0",
     "cli-interact": "^0.1.9",
     "compression": "^1.7.2",
     "cookie-parser": "^1.4.3",

--- a/sharedPlugins/clusterioMod/dole.js
+++ b/sharedPlugins/clusterioMod/dole.js
@@ -55,7 +55,7 @@ class neuralDole {
     divider({
         res,
         object,
-        config,
+		masterConfig,
         prometheusImportGauge
     }){
         let magicData = doleNN.Dose(
@@ -83,7 +83,7 @@ class neuralDole {
 
 		// Remove item from DB and send it
 		this.items.removeItem(object.name, magicData[0]);
-		if(config.logItemTransfers){
+		if (masterConfig.get('log_item_transfers')) {
 			console.log("removed: " + object.name + " " + magicData[0] + " . " + this.items.getItemCount(object.name) + " and sent to " + object.instanceID + " | " + object.instanceName);
 		}
 		prometheusImportGauge.labels(object.instanceID, object.name).inc(Number(magicData[0]) || 0);
@@ -101,7 +101,7 @@ function doleDivider({
 	itemCount,
     object,
 	items,
-    config,
+	masterConfig,
     prometheusDoleFactorGauge,
     prometheusImportGauge,
     req,res,
@@ -120,7 +120,7 @@ function doleDivider({
 	if (itemCount > object.count) {
         //If successful, increase dole
         _doleDivisionFactor[object.name] = Math.max((_doleDivisionFactor[object.name]||0)||1, 1) - 1;
-		if (config.logItemTransfers) {
+		if (masterConfig.get('log_item_transfers')) {
 			console.log("removed: " + object.name + " " + object.count + " . " + itemCount + " and sent to " + object.instanceID + " | " + object.instanceName);
 		}
 		items.removeItem(object.name, object.count)

--- a/test/clusterctl.js
+++ b/test/clusterctl.js
@@ -30,7 +30,7 @@ describe("clusterctl", function() {
 				seq: 1, type: 'list_instances_response',
 				data: {
 					seq: message.seq,
-					list: [{ id: 57, slave_id: 4, name: 'Test Instance' }],
+					list: [{ id: 57, assigned_slave: 4, name: 'Test Instance' }],
 				},
 			});
 		}

--- a/test/file/instances/test/config.json
+++ b/test/file/instances/test/config.json
@@ -1,7 +1,0 @@
-{
-    "id": 1,
-    "name": "test",
-    "factorioPort": null,
-    "clientPort": null,
-    "clientPassword": null
-}

--- a/test/file/instances/test/instance.json
+++ b/test/file/instances/test/instance.json
@@ -1,0 +1,11 @@
+{
+    "groups": [
+        {
+            "name": "instance",
+            "fields": {
+                "id": 1,
+                "name": "test"
+            }
+        }
+    ]
+}

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -45,7 +45,7 @@ describe("Integration of lib/factorio/server", function() {
 		describe(".exampleSettings()", function() {
 			let settings;
 			it("returns an object", async function() {
-				settings = await factorio.FactorioServer.exampleSettings(path.join("factorio", "data"));
+				settings = await server.exampleSettings();
 				assert(typeof settings === "object");
 			});
 

--- a/test/lib/config/classes.js
+++ b/test/lib/config/classes.js
@@ -1,0 +1,567 @@
+"use strict";
+const classes = require("lib/config/classes");
+const assert = require("assert").strict;
+
+
+describe("lib/config/classes", function() {
+	describe("ConfigGroup", function() {
+		class TestGroup extends classes.ConfigGroup { }
+		TestGroup.groupName = "test_group";
+		describe(".define()", function() {
+			it("should throw if groupName is not set", function() {
+				class NoGroupName extends classes.ConfigGroup { }
+				assert.throws(
+					() => NoGroupName.define({ name: "a", type: "string", optional: true }),
+					new Error("Expected ConfigGroup class NoGroupName to have the groupName property set to a string")
+				);
+			});
+			it("should throw on unknown properties", function() {
+				assert.throws(
+					() => TestGroup.define({ name: "a", type: "string", optional: true, invalid: true }),
+					new Error("Unknown property invalid")
+				);
+			});
+			it("should throw on invalid properties", function() {
+				for (let [def, error] of [
+					[
+						{ name: "a", type: "invalid", optional: true },
+						"invalid is not a valid type"
+					],
+					[
+						{ name: [], type: "string", optional: true },
+						"name must be a string"
+					],
+					[
+						{ name: "a", type: "string", enum: true, optional: true },
+						"enum must be an array"
+					],
+					[
+						{ name: "a", title: 2, type: "string", optional: true },
+						"title must be a string"
+					],
+					[
+						{ name: "a", description: 2, type: "string", optional: true },
+						"description must be a string"
+					],
+					[
+						{ name: "a", type: "string", optional: "yes" },
+						"optional must be a boolean"
+					],
+					[
+						{ name: "a", type: "string", initial_value: 1 },
+						"initial_value must match the type or be a function"
+					],
+					[
+						{ name: "a", type: "string" },
+						"Non-optional field a needs an initial_value"
+					],
+				]) {
+					assert.throws(() => TestGroup.define(def), new Error(error));
+				}
+			});
+			it("should throw on missing properties", function() {
+				assert.throws(
+					() => TestGroup.define({ type: "string", optional: true }),
+					new Error("name is required when defining an field")
+				);
+				assert.throws(
+					() => TestGroup.define({ name: "a", optional: true }),
+					new Error("type is required when defining an field")
+				);
+			});
+			it("should allow defining entries", function() {
+				TestGroup.define({ name: "test", type: "string", optional: true });
+				TestGroup.define({ name: "func", type: "number", initial_value: () => 42 });
+				TestGroup.define({ name: "bool", type: "boolean", initial_value: false, optional: true });
+				TestGroup.define({ name: "json", type: "object", initial_value: {} });
+
+				assert(TestGroup._definitions.has("test"), "field test was not defined");
+				assert(TestGroup._definitions.has("func"), "field func was not defined");
+				assert(TestGroup._definitions.has("bool"), "field bool was not defined");
+				assert(TestGroup._definitions.has("json"), "field json was not defined");
+			});
+
+			it("should throw on already defined entries", function() {
+				assert.throws(
+					() => TestGroup.define({ name: "test", type: "string", optional: true }),
+					new Error("Config field test has already been defined")
+				);
+			});
+
+			it("should set the entries on the class", function() {
+				let field = {
+					type: "string",
+					name: "enum",
+					title: "Enum",
+					description: "Enum thingy",
+					enum: ["a", "b", "c"],
+					optional: true,
+					initial_value: "b",
+				}
+				TestGroup.define(field);
+				// Generated properties
+				field.fullName = "test_group.enum";
+
+				assert.deepEqual(TestGroup._definitions.get("enum"), field);
+			})
+		});
+
+		describe("get definitions", function() {
+			it("should give the field definitions", function() {
+				assert.equal(TestGroup.definitions, TestGroup._definitions);
+			});
+		});
+
+		describe(".finalize()", function() {
+			it("should throw if groupName is not set", function() {
+				class NoGroupName extends classes.ConfigGroup { }
+				assert.throws(
+					() => NoGroupName.finalize(),
+					new Error("Expected ConfigGroup class NoGroupName to have the groupName property set to a string")
+				);
+			});
+			it("should throw when creating an instance before finalize", function() {
+				assert.throws(
+					() => new TestGroup(),
+					new Error("Cannot instantiate incomplete ConfigGroup class TestGroup")
+				);
+			});
+
+			it("should not throw", function() {
+				TestGroup.finalize();
+			});
+
+			it("should throw when calling define after finalize", function() {
+				assert.throws(
+					() => TestGroup.define({}),
+					new Error("Cannot define field for ConfigGroup class TestGroup after it has been finalized")
+				);
+			});
+		});
+
+		describe("constructor", function() {
+			it("should create an instance", function() {
+				let testInstance = new TestGroup();
+			});
+		});
+
+		describe(".init()", function() {
+			it("should initialize all fields with defaults", async function() {
+				let testInstance = new TestGroup();
+				await testInstance.init();
+
+				assert.equal(testInstance.get("enum"), "b");
+				assert.equal(testInstance.get("test"), null);
+				assert.equal(testInstance.get("func"), 42);
+			});
+		});
+
+		describe(".serialize()", function() {
+			it("should serialize a basic group", async function() {
+				let testInstance = new TestGroup();
+				await testInstance.init();
+
+				assert.deepEqual(testInstance.serialize(), {
+					name: "test_group",
+					fields: {
+						enum: "b",
+						test: null,
+						func: 42,
+						bool: false,
+						json: {},
+					},
+				});
+			});
+		});
+
+		describe(".load()", function() {
+			it("should load a basic group", async function() {
+				let testInstance = new TestGroup();
+				await testInstance.load({ name: "test_group", fields: {
+					enum: "c",
+					test: "blah",
+					func: 22,
+					bool: null,
+					json: { valid: true },
+				}})
+
+				assert.equal(testInstance.get("enum"), "c");
+				assert.equal(testInstance.get("test"), "blah");
+				assert.equal(testInstance.get("func"), 22);
+				assert.equal(testInstance.get("bool"), null);
+				assert.deepEqual(testInstance.get("json"), { valid: true });
+			});
+			it("should load defaults for missing serialized fields", async function() {
+				let testInstance = new TestGroup();
+				await testInstance.load({ name: "test_group", fields: { enum: "a" } });
+
+				assert.equal(testInstance.get("enum"), "a");
+				assert.equal(testInstance.get("test"), null);
+				assert.equal(testInstance.get("func"), 42);
+			});
+
+			it("should preserve unknown fields when serialized back", async function() {
+				let testFields = {
+					enum: "a",
+					test: "blah",
+					func: 50,
+					bool: false,
+					json: {},
+					alpha: null,
+					beta: "decay",
+					gamma: 99,
+				}
+
+				let testInstance = new TestGroup();
+				await testInstance.load({ name: "test_group", fields: testFields });
+
+				assert.deepEqual(testInstance.serialize().fields, testFields);
+			});
+		});
+
+		describe(".update()", function() {
+			it("should skip updating invalid values", async function() {
+				let testInstance = new TestGroup();
+				await testInstance.init();
+				testInstance.update({ name: "test_group", fields: { enum: "wrong", test: 3, func: null }});
+
+				assert.equal(testInstance.get("enum"), "b");
+				assert.equal(testInstance.get("test"), null);
+				assert.equal(testInstance.get("func"), 42);
+			});
+
+			it("should throw on invalid input", function() {
+				let testInstance = new TestGroup();
+				assert.throws(
+					() => testInstance.update(),
+					new Error("Expected object, not undefined for ConfigGroup")
+				);
+				assert.throws(
+					() => testInstance.update({}),
+					new Error("Expected group name test_group, not undefined")
+				);
+				assert.throws(
+					() => testInstance.update({ name: "test_group" }),
+					new Error("Expected fields to be an object, not undefined")
+				);
+				assert.throws(
+					() => testInstance.update({ name: "test_group", fields: []}),
+					new Error("Expected fields to be an object, not array")
+				);
+				assert.throws(
+					() => testInstance.update({ name: "test_group", fields: null}),
+					new Error("Expected fields to be an object, not null")
+				);
+			});
+		});
+
+		describe(".set()", function() {
+			let testInstance;
+			before(function() {
+				testInstance = new TestGroup();
+				testInstance.update({ name: "test_group", fields: {
+					enum: "a", test: "blah", func: 27,
+				}});
+			});
+
+			it("should throw if field does not exist", function() {
+				assert.throws(
+					() => testInstance.set("bar", 1),
+					new Error("No field named 'bar'")
+				);
+			})
+
+			it("should throw if field is not in enum", function() {
+				assert.throws(
+					() => testInstance.set("enum", "bar"),
+					new Error("Expected one of [a, b, c], not bar")
+				);
+			})
+
+			it("should work if field is in enum", function() {
+				testInstance.set("enum", "c"),
+				assert.equal(testInstance.get("enum"), "c");
+			})
+
+			it("should throw if field is not optional", function() {
+				assert.throws(
+					() => testInstance.set("func", null),
+					new Error("Field func cannot be null")
+				);
+			})
+
+			it("should work if field is optional", function() {
+				testInstance.set("test", "spam"),
+				assert.equal(testInstance.get("test"), "spam");
+			})
+
+			it("should throw if field is of wrong type", function() {
+				assert.throws(
+					() => testInstance.set("test", 1),
+					new Error("Expected type of test to be string, not number")
+				);
+			})
+
+			it("should treat empty string as null", function() {
+				testInstance.set("test", ""),
+				assert.equal(testInstance.get("test"), null);
+			})
+
+			it("should auto convert string to boolean if possible", function() {
+				testInstance.set("bool", "true");
+				assert.equal(testInstance.get("bool"), true);
+				testInstance.set("bool", "false");
+				assert.equal(testInstance.get("bool"), false);
+
+				assert.throws(
+					() => testInstance.set("bool", "blah"),
+					new classes.InvalidValue("Expected type of bool to be boolean, not string")
+				);
+			});
+
+			it("should auto convert string to number if possible", function() {
+				for (let s of [
+					"1",
+					"+23",
+					".23e5",
+					"-.1e-2",
+					"100.0001",
+					"Infinity",
+				]) {
+					testInstance.set("func", s);
+					assert.equal(testInstance.get("func"), Number.parseFloat(s));
+				}
+
+				assert.throws(
+					() => testInstance.set("func", "blah"),
+					new classes.InvalidValue("Expected type of func to be number, not string")
+				);
+			});
+
+			it("should auto convert string to object", function() {
+				testInstance.set("json", '{"json": true}');
+				assert.deepEqual(testInstance.get("json"), { json: true });
+
+				let errMsg;
+				try { JSON.parse("blah"); }
+				catch (err) { errMsg = err.message; }
+				assert.throws(
+					() => testInstance.set("json", "blah"),
+					new classes.InvalidValue(`Error parsing value for json: ${errMsg}`)
+				);
+			});
+		});
+	});
+
+	describe("Config", function() {
+		class AlphaGroup extends classes.ConfigGroup { }
+		AlphaGroup.groupName = "alpha";
+		class BetaGroup extends classes.ConfigGroup { }
+		BetaGroup.groupName = "beta";
+		class TestConfig extends classes.Config { }
+
+		before(function() {
+			AlphaGroup.define({ name: "foo", type: "string", optional: true });
+			AlphaGroup.finalize();
+			TestConfig.registerGroup(AlphaGroup);
+			BetaGroup.define({ name: "bar", type: "number", initial_value: 2 });
+			BetaGroup.finalize();
+			TestConfig.registerGroup(BetaGroup);
+		});
+
+		describe(".registerGroup()", function() {
+			it("should throw if the class is finalized", function() {
+				class TestConfig extends classes.Config { }
+				TestConfig.finalize();
+				class TestGroup extends classes.ConfigGroup { }
+				TestGroup.groupName = "test";
+				TestGroup.finalize();
+
+				assert.throws(
+					() => TestConfig.registerGroup(TestGroup),
+					new Error("Cannot register group on finalized config")
+				);
+			});
+			it("should throw if the group is not finalized", function() {
+				class UnfinishedGroup extends classes.ConfigGroup { }
+
+				assert.throws(
+					() => TestConfig.registerGroup(UnfinishedGroup),
+					new Error("Group must be finalized before it can be registered")
+				);
+			});
+			it("should throw if the group is already registered", function() {
+				assert.throws(
+					() => TestConfig.registerGroup(AlphaGroup),
+					new Error("alpha has already been registered")
+				);
+			});
+		});
+
+		describe("constructor", function() {
+			it("should throw if config is not finalized", function() {
+				assert.throws(
+					() => new TestConfig(),
+					new Error("Cannot instantiate incomplete Config class TestConfig")
+				);
+			});
+			it("should construct a finalized class", function() {
+				TestConfig.finalize();
+				new TestConfig();
+			});
+		});
+
+		describe(".init()", function() {
+			it("should initialize all fields", async function() {
+				let testInstance = new TestConfig();
+				await testInstance.init();
+				assert.equal(testInstance.get("alpha.foo"), null);
+				assert.equal(testInstance.get("beta.bar"), 2);
+			})
+		});
+
+		describe(".serialize()", function() {
+			it("should serialize a basic config", async function() {
+				let testInstance = new TestConfig();
+				await testInstance.init();
+				assert.deepEqual(testInstance.serialize(), {
+					groups: [
+						{
+							name: "alpha",
+							fields: { foo: null },
+						},
+						{
+							name: "beta",
+							fields: { bar: 2 },
+						}
+					]
+				});
+			})
+		});
+
+		describe(".load()", function() {
+			it("should reject on incorrect input passed", async function() {
+				let testInstance = new TestConfig();
+				await assert.rejects(
+					testInstance.load(null),
+					new Error("Expected object, not null for config")
+				);
+				await assert.rejects(
+					testInstance.load(undefined),
+					new Error("Expected object, not undefined for config")
+				);
+				await assert.rejects(
+					testInstance.load({ groups: null }),
+					new Error("Expected groups to be an array, not null")
+				);
+			});
+
+			it("should load defaults for missing serialized groups", async function() {
+				let testInstance = new TestConfig();
+				await testInstance.load({ groups: [{ name: "alpha", fields: { foo: "a" }}] });
+
+				assert.equal(testInstance.get("alpha.foo"), "a");
+				assert.equal(testInstance.get("beta.bar"), 2);
+			});
+
+			it("should preserve unknown groups when serialized back", async function() {
+				let testGroups = [
+					{
+						name: "extra",
+						fields: { blah: true, spam: "foobar" },
+					},
+					{
+						name: "alpha",
+						fields: { foo: "true" },
+					},
+					{
+						name: "beta",
+						fields: { bar: 20 },
+					}
+				]
+
+				let testInstance = new TestConfig();
+				await testInstance.load({ groups: testGroups });
+
+				assert.deepEqual(testInstance.serialize().groups, testGroups);
+			});
+		});
+
+		describe(".update()", function() {
+			it("should update a basic config", async function() {
+				let testInstance = new TestConfig();
+				await testInstance.init();
+				testInstance.update({ groups: [
+					{
+						name: "extra",
+						fields: { blah: true, spam: "baz" },
+					},
+					{
+						name: "beta",
+						fields: { bar: 30 },
+					}
+				]});
+
+				assert.deepEqual(testInstance.serialize(), {
+					groups: [
+						{
+							name: "extra",
+							fields: { blah: true, spam: "baz" },
+						},
+						{
+							name: "alpha",
+							fields: { foo: null },
+						},
+						{
+							name: "beta",
+							fields: { bar: 30 },
+						}
+					],
+				});
+			})
+		});
+
+		describe(".group()", function() {
+			it("should throw if instance is not initialized", function() {
+				let testInstance = new TestConfig();
+				assert.throws(
+					() => testInstance.group("test"),
+					new Error("TestConfig instance is uninitialized")
+				);
+			});
+		});
+
+		describe(".get()", function() {
+			it("should throw if group does not exist", async function() {
+				let testInstance = new TestConfig();
+				await testInstance.init();
+
+				assert.throws(() => testInstance.get("invalid"), new Error("No config group named 'invalid'"))
+			});
+
+			it("should throw if no field is specified", async function() {
+				let testInstance = new TestConfig();
+				await testInstance.init();
+
+				assert.throws(() => testInstance.get("alpha"), new Error("No field named ''"))
+			});
+		});
+
+		describe(".set()", function() {
+			it("should set the value", async function() {
+				let testInstance = new TestConfig();
+				await testInstance.init();
+
+				testInstance.set("alpha.foo", "new value");
+				assert.equal(testInstance.get("alpha.foo"), "new value");
+			});
+		});
+
+		describe("get groups", function() {
+			it("should give the registered group classes", function() {
+				assert.equal(TestConfig.groups, TestConfig._groups);
+			});
+		});
+
+	});
+});

--- a/test/lib/plugin.js
+++ b/test/lib/plugin.js
@@ -34,12 +34,11 @@ describe("lib/plugin", function() {
 		})
 	});
 
-	describe("getPluginInfos()", function() {
+	describe("loadPluginInfos()", function() {
 		let baseDir = path.join('test', 'temp', 'plugin');
 		let emptyDir = path.join(baseDir, 'emptyDir');
 		let emptyPlugin = path.join(baseDir, 'emptyPlugin');
 		let testPlugin = path.join(baseDir, 'testPlugin');
-		let disabledPlugin = path.join(baseDir, 'disabledPlugin');
 		let brokenPlugin = path.join(baseDir, 'brokenPlugin');
 		let invalidPlugin = path.join(baseDir, 'invalidPlugin');
 		before(async function() {
@@ -54,46 +53,32 @@ describe("lib/plugin", function() {
 			}
 
 			await writePlugin(testPlugin, 'test');
-			await writePlugin(disabledPlugin, 'disabled');
-			await fs.outputFile(path.join(disabledPlugin, 'disabled', 'DISABLED'), "");
 			await writePlugin(brokenPlugin, 'broken');
 			await fs.outputFile(path.join(brokenPlugin, 'broken', 'info.js'), "Syntax Error");
 			await writePlugin(invalidPlugin, 'invalid', 'wrong');
 		});
 
 		it("should return an empty array for an empty directory", async function() {
-			assert.deepEqual(await plugin.getPluginInfos(emptyDir), []);
+			assert.deepEqual(await plugin.loadPluginInfos(emptyDir), []);
 		});
 		it("should ignore plugin dirs without info module", async function() {
-			assert.deepEqual(await plugin.getPluginInfos(emptyPlugin), []);
+			assert.deepEqual(await plugin.loadPluginInfos(emptyPlugin), []);
 		});
 		it("should discover test plugin", async function() {
 			assert.deepEqual(
-				await plugin.getPluginInfos(testPlugin),
-				[{ name: 'test', enabled: true }]
-			);
-		});
-		it("should discover disabled plugin", async function() {
-			assert.deepEqual(
-				await plugin.getPluginInfos(disabledPlugin),
-				[{ name: 'disabled', enabled: false }]
-			);
-		});
-		it("should discover disabled plugin", async function() {
-			assert.deepEqual(
-				await plugin.getPluginInfos(disabledPlugin),
-				[{ name: 'disabled', enabled: false }]
+				await plugin.loadPluginInfos(testPlugin),
+				[{ name: 'test' }]
 			);
 		});
 		it("should reject on broken plugin", async function() {
 			await assert.rejects(
-				plugin.getPluginInfos(brokenPlugin),
+				plugin.loadPluginInfos(brokenPlugin),
 				{ message: "PluginError: Unexpected identifier" }
 			);
 		});
 		it("should reject on invalid plugin", async function() {
 			await assert.rejects(
-				plugin.getPluginInfos(invalidPlugin),
+				plugin.loadPluginInfos(invalidPlugin),
 				{ message: `Plugin dir ${invalidPlugin}/invalid does not match the name of the plugin (wrong)` }
 			);
 		});


### PR DESCRIPTION
This is a scaled down version of the proposed configuration system in #200.  The main things that have not been implemented from the proposal is versioning, migrations, and basing a config on another config.  These things have turned out to be a major headache to implement and the utility of them seems small.  I might implement config bases if the need for it is there in the future.

The replacement for versioning and migration of configs is lenient handling of config fields.  So instead of trying to ensure that the config never ever gets an invalid value in it, invalid and missing values are replaced with the default value for that field.  I also made it so that unknown fields are preserved so that uninstalling a plugin doesn't magically erase all the config it had next time the server is started.

There's also some changes to how the config is handled from what was proposed.  I found a simpler way to implement what was needed, which is just a way to config this after all.  It is based on config groups, so instances for example comes with two built-in groups: factorio and instance.  The factorio group contains things like which port to run on, server-settings.json entries to override, etc,, and the instance group contains the id and name of the instance.  Plugins get to define their own groups of config fields that apply either to the master server or per instance, which comes with an enabled field pre defined for them.