### PR TITLE
Brand library mod as alpha

### DIFF
--- a/mod/info.json
+++ b/mod/info.json
@@ -1,9 +1,9 @@
 {
     "name": "clusterio_lib",
     "version": "0.1.0",
-    "title": "Clusterio Library",
+    "title": "Clusterio Library (Alpha)",
     "author": "Clusterio Team",
     "homepage": "https://github.com/clusterio/factorioClusterio",
-    "description": "Library for interfacing with Clusterio.",
+    "description": "Library for interfacing with Clusterio.  Warning: work in progress alpha.",
     "factorio_version": "0.17"
 }


### PR DESCRIPTION
Add alpha notice to the title and description for the Clusterio Library Factorio mod.