### PR TITLE
Fix overflow check in subspace storage

### DIFF
--- a/plugins/subspace_storage/instance.js
+++ b/plugins/subspace_storage/instance.js
@@ -77,8 +77,8 @@ class InstancePlugin extends plugin.BaseInstancePlugin {
 		// XXX this should be done on the lua side
 		// Ensure counts don't overflow
 		for (let item of items) {
-			if (item[1] > 0x7ffffff) {
-				item[1] = 0x7ffffff;
+			if (item[1] > 0x7fffffff) {
+				item[1] = 0x7fffffff;
 			}
 		}
 


### PR DESCRIPTION
Hex was missing an f in the overflow check.
Previous and new value:

|   | Hex | Dec |
|---|---|---|
| Old | 0x7ffffff  | 134.217.727 |
| New | 0x7fffffff | 2.147.483.647|