### PR TITLE
Config events

### DIFF
--- a/clusterctl.js
+++ b/clusterctl.js
@@ -224,6 +224,26 @@ commands.push(new Command({
 }));
 
 commands.push(new Command({
+	definition: ["set-instance-config-prop", "Set property of field in instance config", (yargs) => {
+		yargs.option({
+			"instance": { describe: "Instance to set config on", nargs: 1, type: "string", demandOption: true },
+			"field": { describe: "Field to set", nargs: 1, type: "string", demandOption: true },
+			"prop": { describe: "Property to set", nargs: 1, type: "string", demandOption: true },
+			"value": { describe: "JSON parsed value to set", nargs: 1, type: "string", demandOption: true },
+		});
+	}],
+	handler: async function(args, control) {
+		let instanceId = await resolveInstance(control, args.instance);
+		await link.messages.setInstanceConfigProp.send(control, {
+			instance_id: instanceId,
+			field: args.field,
+			prop: args.prop,
+			value: JSON.parse(args.value),
+		});
+	},
+}));
+
+commands.push(new Command({
 	definition: ['assign-instance', "Assign instance to a slave", (yargs) => {
 		yargs.options({
 			'instance': { describe: "Instance to assign", nargs: 1, type: 'string', demandOption: true },

--- a/lib/config/classes.js
+++ b/lib/config/classes.js
@@ -1,6 +1,9 @@
 // Configuration classes
 "use strict";
 
+const events = require("events");
+const util = require("util");
+
 const { basicType } = require("lib/helpers");
 
 
@@ -55,10 +58,20 @@ function splitOn(separator, string) {
  * Represents a collection of ConfigGroup instances that can be
  * managed as one.
  *
+ * This is an EventEmitter with the following events:
+ * - fieldChanged -
+ *     invoked after a field has been updated in one of the config groups
+ *     belonging to this config.  Takes three parameters: group, field,
+ *     prev.
+ *
+ * @extends events.EventEmitter
+ *
  * @memberof module:lib/config
  */
-class Config {
+class Config extends events.EventEmitter {
 	constructor() {
+		super();
+
 		if (!this.constructor._finalized) {
 			throw new Error(`Cannot instantiate incomplete Config class ${this.constructor.name}`)
 		}
@@ -71,7 +84,7 @@ class Config {
 		for (let [name, GroupClass] of this.constructor._groups) {
 			if (!this._groups.has(name)) {
 				let group = new GroupClass();
-				await group.init();
+				await group.init(this);
 				this._groups.set(name, group);
 			}
 		}
@@ -98,7 +111,7 @@ class Config {
 			}
 
 			let group = new GroupClass();
-			await group.load(serializedGroup);
+			await group.load(this, serializedGroup);
 			this._groups.set(GroupClass.groupName, group);
 		}
 
@@ -123,12 +136,12 @@ class Config {
 	 * Updates all groups in the config with groups in the serialized
 	 * config passed.
 	 */
-	update(serializedConfig) {
+	update(serializedConfig, notify) {
 		this._validate(serializedConfig);
 		for (let serializedGroup of serializedConfig.groups) {
 			let group = this._groups.get(serializedGroup.name);
 			if (group) {
-				group.update(serializedGroup);
+				group.update(serializedGroup, notify);
 			} else {
 				this._unknownGroups.set(serializedGroup.name, serializedGroup);
 			}
@@ -226,6 +239,11 @@ class Config {
 /**
  * Collection of related config entries
  *
+ * Type checks and stores a collection of related config entries.  Attempt
+ * to set invalid values for fields will result in an error thrown while
+ * loading a config with invalid values will result in those being replaced
+ * by the innitial value for those fields.
+ *
  * @memberof module:lib/config
  */
 class ConfigGroup {
@@ -242,6 +260,7 @@ class ConfigGroup {
 
 		this._fields = new Map();
 		this._unknownFields = new Map();
+		this._config = null;
 	}
 
 	/**
@@ -250,7 +269,9 @@ class ConfigGroup {
 	 * Computes and assigns the initial values for all fields of the
 	 * config group.
 	 */
-	async init() {
+	async init(config) {
+		this._config = config;
+
 		for (let [name, def] of this.constructor._definitions) {
 			if (this._fields.has(name)) {
 				continue;
@@ -275,9 +296,9 @@ class ConfigGroup {
 	 * group and then initializes any possible missing fields from it to
 	 * their default values.
 	 */
-	async load(serializedGroup) {
-		this.update(serializedGroup);
-		await this.init();
+	async load(config, serializedGroup) {
+		this.update(serializedGroup, false);
+		await this.init(config);
 	}
 
 	/**
@@ -345,7 +366,11 @@ class ConfigGroup {
 			}
 		}
 
+		let prev = this._fields.get(name);
 		this._fields.set(name, value);
+		if (this._config && !util.isDeepStrictEqual(value, prev)) {
+			this._config.emit("fieldChanged", this, name, prev);
+		}
 	}
 
 	/**
@@ -354,7 +379,7 @@ class ConfigGroup {
 	 * Overwrites the values of all the fields in this config group that
 	 * has a valid value in the passed serialized group with that value.
 	 */
-	update(serializedGroup) {
+	update(serializedGroup, notify) {
 		if (basicType(serializedGroup) !== "object") {
 			throw new Error(`Expected object, not ${basicType(serializedGroup)} for ConfigGroup`);
 		}
@@ -388,7 +413,11 @@ class ConfigGroup {
 				continue;
 			}
 
+			let prev = this._fields.get(name);
 			this._fields.set(name, value);
+			if (notify && this._config && !util.isDeepStrictEqual(value, prev)) {
+				this._config.emit("fieldChanged", this, name, prev);
+			}
 		}
 	}
 

--- a/lib/config/classes.js
+++ b/lib/config/classes.js
@@ -165,6 +165,14 @@ class Config extends events.EventEmitter {
 	}
 
 	/**
+	 * Set property of an object value for a config field
+	 */
+	setProp(name, prop, value) {
+		let [group, field] = splitOn('.', name);
+		return this.group(group).setProp(field, prop, value);
+	}
+
+	/**
 	 * Get the config group instance with the given name
 	 */
 	group(name) {
@@ -327,12 +335,13 @@ class ConfigGroup {
 	 * The field must be defined for the config group and the value is
 	 * type checked against the field definition.
 	 *
+	 * @throws {module:lib/config.InvalidField} if field is not defined.
 	 * @throws {module:lib/config.InvalidValue} if value is not allowed for the field.
 	 */
 	set(name, value) {
 		let def = this.constructor._definitions.get(name);
 		if (!def) {
-			throw new Error(`No field named '${name}'`);
+			throw new InvalidField(`No field named '${name}'`);
 		}
 
 		// Empty strings are treates as null
@@ -378,6 +387,40 @@ class ConfigGroup {
 		let prev = this._fields.get(name);
 		this._fields.set(name, value);
 		if (this._config && !util.isDeepStrictEqual(value, prev)) {
+			this._config.emit("fieldChanged", this, name, prev);
+		}
+	}
+
+	/**
+	 * Set property of object field
+	 *
+	 * Update value of stored object field by setting the specified property
+	 * on it.  The field must be defined as an object for the config group.
+	 *
+	 * @throws {module:lib/config.InvalidField} if field is not defined.
+	 * @throws {module:lib/config.InvalidValue} if field is not an object.
+	 */
+	setProp(name, prop, value) {
+		let def = this.constructor._definitions.get(name);
+		if (!def) {
+			throw new InvalidField(`No field named '${name}'`);
+		}
+
+		if (def.type !== "object") {
+			throw new InvalidValue(`Cannot set property on non-object field '${name}'`);
+		}
+
+		let prev = this._fields.get(name);
+		let updated = {};
+		if (prev !== null) {
+			for (let [key, value] of Object.entries(prev)) {
+				updated[key] = value;
+			}
+		}
+
+		updated[prop] = value;
+		this._fields.set(name, updated);
+		if (this._config && !util.isDeepStrictEqual(updated, prev)) {
 			this._config.emit("fieldChanged", this, name, prev);
 		}
 	}

--- a/lib/config/classes.js
+++ b/lib/config/classes.js
@@ -112,7 +112,7 @@ class Config extends events.EventEmitter {
 
 			let group = new GroupClass();
 			await group.load(this, serializedGroup);
-			this._groups.set(GroupClass.groupName, group);
+			this._groups.set(group.name, group);
 		}
 
 		await this.init();
@@ -302,6 +302,15 @@ class ConfigGroup {
 	}
 
 	/**
+	 * Name of the group
+	 *
+	 * Shortcut for `group.constructor.groupName`
+	 */
+	get name() {
+		return this.constructor.groupName;
+	}
+
+	/**
 	 * Get value for field
 	 */
 	get(name) {
@@ -384,8 +393,8 @@ class ConfigGroup {
 			throw new Error(`Expected object, not ${basicType(serializedGroup)} for ConfigGroup`);
 		}
 
-		if (serializedGroup.name !== this.constructor.groupName) {
-			throw new Error(`Expected group name ${this.constructor.groupName}, not ${serializedGroup.name}`);
+		if (serializedGroup.name !== this.name) {
+			throw new Error(`Expected group name ${this.name}, not ${serializedGroup.name}`);
 		}
 
 		if (basicType(serializedGroup.fields) !== "object") {
@@ -435,7 +444,7 @@ class ConfigGroup {
 		}
 
 		return {
-			name: this.constructor.groupName,
+			name: this.name,
 			fields,
 		};
 	}

--- a/lib/link/messages.js
+++ b/lib/link/messages.js
@@ -312,6 +312,17 @@ messages.setInstanceConfigField = new Request({
 	},
 });
 
+messages.setInstanceConfigProp = new Request({
+	type: "set_instance_config_prop",
+	links: ["control-master"],
+	requestProperties: {
+		"instance_id": { type: "integer" },
+		"field": { type: "string" },
+		"prop": { type: "string" },
+		"value": {},
+	},
+});
+
 messages.assignInstanceCommand = new Request({
 	type: 'assign_instance_command',
 	links: ['control-master'],

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -43,6 +43,19 @@ class BaseInstancePlugin {
 	async init() { }
 
 	/**
+	 * Called when the value of a config field changed.
+	 *
+	 * Invoked after the value of the config field given by `field` has
+	 * changed.
+	 *
+	 * @param {module:lib/config.ConfigGroup} group -
+	 *     The group who's field got changed on.
+	 * @param {string} field - Name of the field that changed.
+	 * @param prev - The previous value of the field.
+	 */
+	async onInstanceConfigFieldChanged(group, field, prev) { }
+
+	/**
 	 * Called before collecting Prometheus metrics
 	 *
 	 * Invoked before the default metrics of prometheus is collected.  Note

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -334,6 +334,30 @@ function attachPluginMessages(link, pluginInfo, plugin) {
 	}
 }
 
+/**
+ * Invokes the given hook on all plugins
+ *
+ * @param {Map<string, Object} plugins -
+ *     Mapping of plugin names to plugins to invoke the hook on.
+ * @param {string} hook - Name of hook to invoke.
+ * @param {...*} args - Arguments to pass on to the hook.
+ * @returns {Array} Non-empty return values from the hooks.
+ */
+async function invokeHook(plugins, hook, ...args) {
+	let results = [];
+	for (let [name, plugin] of plugins) {
+		try {
+			let result = await plugin[hook](...args);
+			if (result !== undefined) {
+				results.push(result);
+			}
+		} catch (err) {
+			console.error(`Ignoring error from plugin ${name} in ${hook}:`, err);
+		}
+	}
+	return results;
+}
+
 
 module.exports = {
 	BaseInstancePlugin,
@@ -341,4 +365,5 @@ module.exports = {
 
 	loadPluginInfos,
 	attachPluginMessages,
+	invokeHook,
 };

--- a/master.js
+++ b/master.js
@@ -128,12 +128,10 @@ async function getMetrics(req, res, next) {
 	endpointHitCounter.labels(req.route.path).inc();
 
 	let results = []
-	for (let masterPlugin of masterPlugins.values()) {
-		let pluginResults = await masterPlugin.onMetrics();
-		if (pluginResults !== undefined) {
-			for await (let result of pluginResults) {
-				results.push(result)
-			}
+	let pluginResults = await plugin.invokeHook(masterPlugins, "onMetrics");
+	for (let metricIterator of pluginResults) {
+		for await (let metric of metricIterator) {
+			results.push(metric)
 		}
 	}
 
@@ -291,11 +289,7 @@ async function shutdown() {
 		await saveMap(masterConfig.get('master.database_directory'), "slaves.json", db.slaves);
 		await saveInstances(masterConfig.get('master.database_directory'), "instances.json", db.instances);
 
-		for (let [pluginName, masterPlugin] of masterPlugins) {
-			let startTime = Date.now();
-			await masterPlugin.onShutdown();
-			console.log(`Plugin ${pluginName} shutdown in ${Date.now() - startTime}ms`);
-		}
+		await plugin.invokeHook(masterPlugins, "onShutdown");
 
 		stopAcceptingNewSessions = true;
 
@@ -427,9 +421,7 @@ class BaseConnection extends link.Link {
 	}
 
 	async prepareDisconnectRequestHandler(message, request) {
-		for (let masterPlugin of masterPlugins.values()) {
-			await masterPlugin.onPrepareSlaveDisconnect(this);
-		}
+		await plugin.invokeHook(masterPlugins, "onPrepareSlaveDisconnect", this);
 		this.connector.setClosing();
 		return await super.prepareDisconnectRequestHandler(message, request);
 	}
@@ -652,9 +644,7 @@ class SlaveConnection extends BaseConnection {
 		let prev = instance.status;
 		instance.status = "initialized";
 		console.log(`Clusterio | Instance ${instance.config.get("instance.name")} Initialized`)
-		for (let masterPlugin of masterPlugins.values()) {
-			await masterPlugin.onInstanceStatusChanged(instance, prev);
-		}
+		await plugin.invokeHook(masterPlugins, "onInstanceStatusChanged", instance, prev);
 	}
 
 	async instanceStartedEventHandler(message, event) {
@@ -662,9 +652,7 @@ class SlaveConnection extends BaseConnection {
 		let prev = instance.status;
 		instance.status = "running";
 		console.log(`Clusterio | Instance ${instance.config.get("instance.name")} Started`)
-		for (let masterPlugin of masterPlugins.values()) {
-			await masterPlugin.onInstanceStatusChanged(instance, prev);
-		}
+		await plugin.invokeHook(masterPlugins, "onInstanceStatusChanged", instance, prev);
 	}
 
 	async instanceStoppedEventHandler(message, event) {
@@ -672,9 +660,7 @@ class SlaveConnection extends BaseConnection {
 		let prev = instance.status;
 		instance.status = "stopped";
 		console.log(`Clusterio | Instance ${instance.config.get("instance.name")} Stopped`)
-		for (let masterPlugin of masterPlugins.values()) {
-			await masterPlugin.onInstanceStatusChanged(instance, prev);
-		}
+		await plugin.invokeHook(masterPlugins, "onInstanceStatusChanged", instance, prev);
 	}
 
 	async updateInstancesEventHandler(message) {
@@ -700,9 +686,7 @@ class SlaveConnection extends BaseConnection {
 					let prev = masterInstance.status;
 					masterInstance.status = instance.status;
 					if (prev !== undefined) {
-						for (let masterPlugin of masterPlugins.values()) {
-							await masterPlugin.onInstanceStatusChanged(instance, prev);
-						}
+						await plugin.invokeHook(masterPlugins, "onInstanceStatusChanged", instance, prev);
 					}
 				}
 				continue;

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -4,7 +4,7 @@ const path = require("path");
 const validateHTML = require('html5-validator');
 const parallel = require('mocha.parallel');
 
-const { slowTest, get, exec, controlConfigPath, instancesDir } = require("./index");
+const { slowTest, get, exec, sendRcon, controlConfigPath, instancesDir } = require("./index");
 
 
 describe("Integration of Clusterio", function() {
@@ -79,6 +79,91 @@ describe("Integration of Clusterio", function() {
 				slowTest(this);
 				await exec(`node clusterctl --config ${controlConfigPath} send-rcon --instance test --command test`);
 				// TODO check that the command was received
+			});
+		});
+
+		describe("set-instance-config-prop", function() {
+			it("applies factorio settings while running", async function() {
+				slowTest(this);
+
+				let testConfigs = [
+					// json name, value to set,
+					// /config name, expected result
+					[
+						"afk_autokick_interval", 2,
+						"afk-auto-kick", "Kick if AFK for more than 2 minutes.",
+					],
+					[
+						"allow_commands", true,
+						"allow-commands", "Yes",
+					],
+					[
+						"autosave_interval", 17,
+						"autosave-interval", "Autosave every 17 minutes.",
+					],
+					[
+						"autosave_only_on_server", false,
+						"autosave-only-on-server", "Autosave only on server: false.",
+					],
+					[
+						"description", "A test server blah blah",
+						"description", "Server description: A test server blah blah",
+					],
+					[
+						"ignore_player_limit_for_returning_players", true,
+						"ignore-player-limit-for-returning-players", "Ignore player limit for returning players: true."
+					],
+					[
+						"max_players", 11,
+						"max-players", "11",
+					],
+					[
+						"max_upload_slots", 7,
+						"max-upload-slots", "7 slots.",
+					],
+					[
+						"max_upload_in_kilobytes_per_second", 123,
+						"max-upload-speed", "123 kilobytes per second.",
+					],
+					[
+						"name", "A test",
+						"name", "Server name: A test",
+					],
+					[
+						"only_admins_can_pause_the_game", false,
+						"only-admins-can-pause", "Only admins can pause: false.",
+					],
+					[
+						"game_password", "secret",
+						"password", "The server currently has a password.",
+					],
+					[
+						"tags", ["clusterio", "test-tag"],
+						"tags", "Server tags: clusterio test-tag",
+					],
+					[
+						"visibility", { lan: false, public: false },
+						"visibility-lan", "LAN visibility: false.",
+					],
+
+					// Public visibility must be reset before verify can be reset
+					[
+						"require_user_verification", false,
+						"require-user-verification", "Verify user identity: false.",
+					],
+				];
+
+				for (let [prop, value, , ] of testConfigs) {
+					value = `"'${JSON.stringify(value).replace(/"/g, process.platform === "win32" ? '""' : '\\"')}'"`;
+					let args = `--instance test --field factorio.settings --prop ${prop} --value ${value}`;
+					await exec(`node clusterctl --config ${controlConfigPath} set-instance-config-prop ${args}`);
+				}
+
+				// Do this afterwards to leave enough to time for the
+				// changes to have propogated.
+				for (let [, , configName, expectedResult] of testConfigs) {
+					assert.equal(await sendRcon(44, `/config get ${configName}`), `${expectedResult}\n`);
+				}
 			});
 		});
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -6,8 +6,30 @@ const needle = require("needle");
 const util = require("util");
 const events = require("events");
 
+const link = require("lib/link");
 const server = require("lib/factorio/server");
 
+
+class TestControl extends link.Link {
+	constructor(connector) {
+		super("control", "master", connector);
+		link.attachAllMessages(this);
+	}
+
+	async prepareDisconnectRequestHandler(message, request) {
+		this.connector.setClosing();
+		return await super.prepareDisconnectRequestHandler(message, request);
+	}
+
+	async debugWsMessageEventHandler() { }
+	async instanceOutputEventHandler() { }
+}
+
+class TestControlConnector extends link.WebSocketClientConnector {
+	register() {
+		this.sendHandshake("register_control", { token: this.token, agent: "clusterctl", version: "test" });
+	}
+}
 
 // Mark that this test takes a lot of time, or depeneds on a test
 // that takes a lot of time.
@@ -29,6 +51,7 @@ async function get(path) {
 
 let masterProcess;
 let slaveProcess;
+let control;
 
 let url = "https://localhost:4443/";
 let token = jwt.sign({ id: "api" }, "TestSecretDoNotUse");
@@ -41,6 +64,11 @@ let controlConfigPath = path.join("temp", "test", "control-integration.json");
 async function exec(...args) {
 	console.log(args[0]);
 	return await util.promisify(child_process.exec)(...args);
+}
+
+async function sendRcon(instanceId, command) {
+	let response = await link.messages.sendRcon.send(control, { instance_id: instanceId, command })
+	return response.result;
 }
 
 function spawn(name, cmd, waitFor) {
@@ -94,6 +122,11 @@ before(async function() {
 
 	masterProcess = await spawn("master:", `node master --config ${masterConfigPath} run`, "All plugins loaded");
 	slaveProcess = await spawn("slave:", `node slave --config ${slaveConfigPath} run`, "SOCKET | received ready from master");
+
+	let controlConnector = new TestControlConnector(url, 2);
+	controlConnector.token = token;
+	control = new TestControl(controlConnector);
+	await controlConnector.connect();
 });
 
 after(async function() {
@@ -118,9 +151,13 @@ process.on("exit", () => {
 
 
 module.exports = {
+	TestControl,
+	TestControlConnector,
 	slowTest,
 	get,
 	exec,
+	sendRcon,
+	control,
 
 	url,
 	token,

--- a/test/integration/link.js
+++ b/test/integration/link.js
@@ -1,31 +1,8 @@
 const assert = require("assert").strict;
 const events = require("events");
 
-const link = require("lib/link");
+const { TestControlConnector, TestControl, get, exec, url, token } = require("./index");
 
-const { get, exec, url, token } = require("./index");
-
-
-class TestControl extends link.Link {
-	constructor(connector) {
-		super("control", "master", connector);
-		link.attachAllMessages(this);
-	}
-
-	async prepareDisconnectRequestHandler(message, request) {
-		this.connector.setClosing();
-		return await super.prepareDisconnectRequestHandler(message, request);
-	}
-
-	async debugWsMessageEventHandler() { }
-	async instanceOutputEventHandler() { }
-}
-
-class TestControlConnector extends link.WebSocketClientConnector {
-	register() {
-		this.sendHandshake("register_control", { token: this.token, agent: "clusterctl", version: "test" });
-	}
-}
 
 describe("Integration of lib/link", function() {
 	let control;

--- a/test/lib/config/classes.js
+++ b/test/lib/config/classes.js
@@ -156,6 +156,14 @@ describe("lib/config/classes", function() {
 			});
 		});
 
+		describe("get name", function() {
+			it("should give the name of the group", async function() {
+				let testInstance = new TestGroup();
+				await testInstance.init();
+				assert.equal(testInstance.name, "test_group");
+			});
+		});
+
 		describe(".serialize()", function() {
 			it("should serialize a basic group", async function() {
 				let testInstance = new TestGroup();

--- a/test/lib/plugin.js
+++ b/test/lib/plugin.js
@@ -119,4 +119,31 @@ describe("lib/plugin", function() {
 			);
 		});
 	});
+
+	describe("invokeHook()", function() {
+		let betaTestCalled = false;
+		let plugins = new Map([
+			["alpha", {
+				test: async function() { },
+				pass: async function(arg) { return arg; },
+				error: async function() { throw new Error("Test"); },
+			}],
+			["beta", {
+				test: async function() { betaTestCalled = true; },
+				pass: async function() { },
+				error: async function() { },
+			}],
+		]);
+		it("should invoke the hook on the plugin", async function() {
+			await plugin.invokeHook(plugins, "test");
+			assert(betaTestCalled, "Hook was not called");
+		});
+		it("should pass and return args", async function() {
+			let result = await plugin.invokeHook(plugins, "pass", 1234);
+			assert.deepEqual(result, [1234]);
+		});
+		it("should ignore errors", async function() {
+			await plugin.invokeHook(plugins, "error");
+		});
+	});
 });

--- a/test/slave.js
+++ b/test/slave.js
@@ -157,7 +157,8 @@ describe("Slave testing", function() {
 		it("should discover test instance", async function() {
 			let logger = { log: () => {}, error: () => {} };
 			let instancePath = path.join("test", "file", "instances");
-			let instanceInfos = await slave._discoverInstances(instancePath, logger);
+			let instanceInfos = new Map();
+			await slave._discoverInstances(instanceInfos, instancePath, logger);
 
 			let referenceConfig = new config.InstanceConfig();
 			await referenceConfig.init();


### PR DESCRIPTION
Implementation of config update event, plugin hook for config update, and live update of factorio.settings to running instances using the `/config set` command.  This allows updating things like the name, description, tags, max players, visibility, upload slots, etc, via the Clusterio interface without having to restart the instance for it to take effect.

I also added a set-instance-config-prop command for updating a single property of an object config without having to give the whole object.  This makes the testing simple and allows updating for example only the name of the factorio.settings object config.