### PR TITLE
Fixed syntax error in subspace_storage plugin

### DIFF
--- a/plugins/subspace_storage/static/storage.js
+++ b/plugins/subspace_storage/static/storage.js
@@ -1,6 +1,6 @@
 // function to draw data we recieve from ajax requests
 "use strict";
-_lastData = [];
+var _lastData = [];
 function drawcontents(data) {
 	data = data || _lastData; //Cache data so we can drawcontents without waiting for the server, for the search box.
 	_lastData = data;


### PR DESCRIPTION
Fixed a syntax error on line 3 of storage.js in the subspace_storage plugin static directory to let the script run and display items in the Clusterio webpage. Previously no items were displayed and an error was hinted in the javascript console in a browser.