### PR TITLE
master.js: fix missing response for /api/getID

### DIFF
--- a/master.js
+++ b/master.js
@@ -329,6 +329,7 @@ app.post("/api/getID", authenticate.middleware, function(req,res) {
 		}
 		// console.log("Slave registered: " + slaves[req.body.unique].mac + " : " + slaves[req.body.unique].serverPort+" at " + slaves[req.body.unique].publicIP + " with name " + slaves[req.body.unique].instanceName);
 	}
+	res.sendStatus(200);
 });
 /**
 POST Allows you to add metadata related to slaves for other tools, like owner data, descriptions or statistics.


### PR DESCRIPTION
According to rfc2616#section-6:

> After receiving and interpreting a request message, a server
> responds with an HTTP response message.

That response was missing for /api/getID which could lead to
EMFILE, because needle module was waiting indefiniately for
response from server. Since client sends /api/getID once every 10
seconds, this piles up, ultimately reaching ulimit for opened file
descriptors.

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>