### PR TITLE
Remove bcrypt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
   "dependencies": {
     "as-table": "^1.0.31",
     "base64url": "^3.0.0",
-    "bcrypt": "=3.0.6",
-    "bcrypt-promise": "^2.0.0",
     "body-parser": "^1.18.2",
     "chalk": "^3.0.0",
     "cli-interact": "^0.1.9",


### PR DESCRIPTION
Remove the unused dependencies to bcrypt and bcrypt-promise.  These were used by the playerManager plugin to implement password based authentication, but this plugin is likely not going to be ported to 2.0.