### PR TITLE
Fix logger.warning is not a function

### DIFF
--- a/slave.js
+++ b/slave.js
@@ -1188,11 +1188,11 @@ async function symlinkMods(instance, sharedMods, logger) {
 				}
 
 			} else {
-				logger.warning(`Warning: ignoring file '${entry.name}' in sharedMods`);
+				logger.warn(`Warning: ignoring file '${entry.name}' in sharedMods`);
 			}
 
 		} else {
-			logger.warning(`Warning: ignoring non-file '${entry.name}' in sharedMods`);
+			logger.warn(`Warning: ignoring non-file '${entry.name}' in sharedMods`);
 		}
 	}
 }

--- a/test/slave.js
+++ b/test/slave.js
@@ -92,7 +92,7 @@ describe("Slave testing", function() {
 	describe("symlinkMods()", function() {
 		let testDir = path.join("temp", "test", "symlink");
 		let discardingLogger = {
-			warning: function() { },
+			warn: function() { },
 			log: function() { },
 		};
 


### PR DESCRIPTION
Replace logger.warning with logger.warn as I incorrectly assumed the
warning method of console was called console.warning instead of
console.warn.

Fixes #303.