### PR TITLE
Rework instance status

### DIFF
--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -804,7 +804,7 @@ messages.debugWsMessage = new Event({
 
 messages.instanceInitialized = new Event({
 	type: "instance_initialized",
-	links: ["instance-slave", "slave-master"],
+	links: ["instance-slave"],
 	eventProperties: {
 		"instance_id": { type: "integer" },
 		"plugins": {
@@ -813,18 +813,14 @@ messages.instanceInitialized = new Event({
 		},
 	},
 });
-messages.instanceStarted = new Event({
-	type: "instance_started",
+messages.instanceStatusChanged = new Event({
+	type: "instance_status_changed",
 	links: ["instance-slave", "slave-master"],
 	eventProperties: {
 		"instance_id": { type: "integer" },
-	},
-});
-messages.instanceStopped = new Event({
-	type: "instance_stopped",
-	links: ["instance-slave", "slave-master"],
-	eventProperties: {
-		"instance_id": { type: "integer" },
+		"status": { enum: [
+			"stopped", "starting", "running", "creating_save", "exporting_data",
+		]},
 	},
 });
 
@@ -840,7 +836,9 @@ messages.updateInstances = new Event({
 				required: ["serialized_config", "status"],
 				properties: {
 					"serialized_config": { type: "object" },
-					"status": { enum: ["stopped", "initialized", "running"] },
+					"status": { enum: [
+						"stopped", "starting", "running", "creating_save", "exporting_data",
+					]},
 				},
 			},
 		},

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -290,11 +290,14 @@ messages.listInstances = new Request({
 			type: "array",
 			items: {
 				additionalProperties: false,
-				required: ["name", "id", "assigned_slave"],
+				required: ["name", "id", "assigned_slave", "status"],
 				properties: {
 					"name": { type: "string" },
 					"id": { type: "integer" },
 					"assigned_slave": { type: ["null", "integer"] },
+					"status": { enum: [
+						"unknown", "unassigned", "stopped", "starting", "running", "creating_save", "exporting_data",
+					]},
 				},
 			},
 		},

--- a/packages/lib/plugin.js
+++ b/packages/lib/plugin.js
@@ -226,10 +226,23 @@ class BaseMasterPlugin {
 	 *
 	 * Invoked when the master server has received notice from a slave that
 	 * the running status of an instance has changed.  The possible statuses
-	 * are `stopped` meaning it is not loaded or running, `initialized`
-	 * meaning the instance has initialized and is starting up the Factorio
-	 * server, and `running` which means the Factorio server it manages is
-	 * up and running.
+	 * that can be notified about are:
+	 * - `stopped`: Instance is no longer running.
+	 * - `starting`: Instance is in the process of starting up.
+	 * - `running`: Instance startup completed and is now running.
+	 * - `creating_save`: Instance is in the process of creating a save.
+	 * - `exporting_data`: Instance is in the process of exporting item
+	 *   icons and locale data.
+	 *
+	 * On master startup all known instances gets the status `unknown` if
+	 * they are assigned to a slave, when the slave then connects to the
+	 * master and informs of the current status of its instances this hook
+	 * is invoked for all those instances.  You can detect this situation by
+	 * checking if prev equals `unknown`.
+	 *
+	 * Note that it's possible for status change notification to get lost in
+	 * the case of network outages if reconnect fails to re-establish the
+	 * session between the master server and the slave.
 	 *
 	 * @param {Object} instance - the instance that changed.
 	 * @param {string} prev - the previous status of the instance.

--- a/packages/master/master.js
+++ b/packages/master/master.js
@@ -612,6 +612,7 @@ class ControlConnection extends BaseConnection {
 				id: instance.config.get("instance.id"),
 				name: instance.config.get("instance.name"),
 				assigned_slave: instance.config.get("instance.assigned_slave"),
+				status: instance.status,
 			});
 		}
 		return { list };

--- a/test/lib/command.js
+++ b/test/lib/command.js
@@ -24,7 +24,7 @@ describe("lib/command", function() {
 				seq: 1, type: "list_instances_response",
 				data: {
 					seq: message.seq,
-					list: [{ id: 57, assigned_slave: 4, name: "Test Instance" }],
+					list: [{ id: 57, assigned_slave: 4, name: "Test Instance", status: "stopped" }],
 				},
 			});
 		} else if (message.type === "list_roles_request") {


### PR DESCRIPTION
Extended implementation of #312 which adds unassigned and unknown statuses and replaces the initialized status with starting, creating_save, and exporting_data.