### PR TITLE
Fix 'Got no "ok"' log spam

### DIFF
--- a/client.js
+++ b/client.js
@@ -716,7 +716,7 @@ async function instanceManagement(instanceconfig) {
 							console.error(err);
 						} else if (response && response.body) {
 							// In the future we might be interested in whether or not we actually manage to send it, but honestly I don't care.
-							if(response.body !== "ok") {
+							if (response.body.toLowerCase() !== "ok") {
                                 console.log("Got no \"ok\" while registering our precense with master "+config.masterIP+" at " + payload.time);
                                 console.log(response.body);
                             }


### PR DESCRIPTION
In #307 I incorrectly assumed that the response sent wouldn't matter as it hadn't sent a response in ages.  That was not the case and the client code checks to see if the response is "ok" while .sendStatus(200) sends a response of "OK".  Fix log spam by doing a case insensitive comparison of the response.