### PR TITLE
Improvements from investigating RCON performance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -214,7 +214,7 @@ module.exports = {
 		"no-useless-rename": "error",
 		"no-useless-return": "error",
 		"no-var": "warn",
-		"no-void": "error",
+		"no-void": ["error", { "allowAsStatement": true }],
 		"no-warning-comments": "off",
 		"no-whitespace-before-property": "error",
 		"nonblock-statement-body-position": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Version 2.0.0
   Clusterio core.  Previously this was handled by the playerManager plugin.
 - Added stripping of long paths in the Factorio server log.
 - Added option to configure maximum number of commands to send in parallel.
+- Added option to auto start instances on slave startup.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Version 2.0.0
 - Added synchronization of in-game adminlist, banlist and whitelist to
   Clusterio core.  Previously this was handled by the playerManager plugin.
 - Added stripping of long paths in the Factorio server log.
+- Added option to configure maximum number of commands to send in parallel.
 
 ### Changes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,6 +218,15 @@ directory for the instance is created on the slave.
 Defaults to null meaning not assigned.
 
 
+### instance.auto_start
+
+If enabled start this instance when the slave it is assigned to is
+started up.  Does not affect start or stop of the instance while the
+slave is running.
+
+Defaults to false
+
+
 ### factorio.version
 
 Version of Factorio to use for this instance.  Can be a version like

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,6 +342,39 @@ banned status while the instance is running.
 Defaults to true
 
 
+### factorio.max_concurrent_commands
+
+Maximum number of commands being transmitted into the game in parallel.
+Since the rate at which long commands are streamed into the game is by
+default limeted to 100 bytes/tick and scales down to 25 bytes/tick when
+there's 20 players connected, long commands can hold up the command
+interface and cause large latencies in getting data pushed into the
+game. (The rates are controlled by the `segment_size` options in the
+server settings.)  To counteract this Clusterio sends up to this
+configured value number of commands in parallel over the RCON interface.
+This causes the game updates sent to clients to have this many command
+streams in parallel contained in them, drastically increasing the
+maxiumum size they can become.  Since commands are only processed so
+ofter the maximum rate of commands that can be sustained is roughly 30
+times this configured value per second, though note that large commands
+will lower this value.
+
+The game updates sent by the server is split into roughly 500 byte
+packets, and if any one of those parts are lost the entire update is
+resent.  This means a high number of concurrent commands can amplify
+resends due to packet loss and degrade the player experience up to the
+point of becomming completely unplayable.
+
+Prior to 0.18.7 the maximum practical size of game update sent where
+arround 8 kB due to the UDP receive buffer on windows defaulting to this
+value, larger updates would not get through the receive buffer and cause
+the connection to drop.  To stay below the 8 kB limit the maximum safe
+value for this option would be around 7000 / (3 * game_speed *
+maximum_segment_size), which is around 20 in normal circumstances.
+
+Defaults to 5
+
+
 ### <plugin_name>.enabled
 
 Whether to enable the given plugin on the instance.  Note that plugins

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -230,11 +230,11 @@ Communicating with Factorio
 
 For pushing data into Factorio there's RCON, which lets you send
 arbitrary Lua commands to invoke whatever code you want in the game.
-This is done by calling the `sendRcon` method on the instance's server object.
+This is done by calling the `sendRcon` method on the plugin object.
 For example:
 
     async onStart() {
-        let response = await this.instance.server.sendRcon(
+        let response = await this.sendRcon(
             "/sc rcon.print('data')"
         );
 

--- a/packages/ctl/ctl.js
+++ b/packages/ctl/ctl.js
@@ -203,13 +203,13 @@ instanceConfigCommands.add(new libCommand.Command({
 instanceCommands.add(instanceConfigCommands);
 
 instanceCommands.add(new libCommand.Command({
-	definition: ["assign <instance> <slave>", "Assign instance to a slave", (yargs) => {
+	definition: ["assign <instance> [slave]", "Assign instance to a slave", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to assign", type: "string" });
-		yargs.positional("slave", { describe: "Slave to assign to", type: "string" });
+		yargs.positional("slave", { describe: "Slave to assign to or unassign if none", type: "string" });
 	}],
 	handler: async function(args, control) {
 		let instanceId = await libCommand.resolveInstance(control, args.instance);
-		let slaveId = await libCommand.resolveSlave(control, args.slave);
+		let slaveId = args.slave ? await libCommand.resolveSlave(control, args.slave) : null;
 		await libLink.messages.assignInstanceCommand.send(control, {
 			instance_id: instanceId,
 			slave_id: slaveId,

--- a/packages/lib/config/definitions.js
+++ b/packages/lib/config/definitions.js
@@ -280,6 +280,12 @@ FactorioGroup.define({
 	type: "boolean",
 	initial_value: true,
 });
+FactorioGroup.define({
+	name: "max_concurrent_commands",
+	description: "Maximum number of RCON commands trasmitted in parallel",
+	type: "number",
+	initial_value: 5,
+});
 FactorioGroup.finalize();
 
 /**

--- a/packages/lib/config/definitions.js
+++ b/packages/lib/config/definitions.js
@@ -196,6 +196,12 @@ InstanceGroup.define({
 	type: "number",
 	optional: true,
 });
+InstanceGroup.define({
+	name: "auto_start",
+	description: "Automatically start this instance when the slave hosting it is started up",
+	type: "boolean",
+	initial_value: false,
+});
 InstanceGroup.finalize();
 
 /**

--- a/packages/lib/helpers.js
+++ b/packages/lib/helpers.js
@@ -19,6 +19,41 @@ function basicType(value) {
 	return typeof value;
 }
 
+
+/**
+ * Asynchronously wait for the given duration
+ *
+ * @param {number} duration - Time to wait for in milliseconds.
+ */
+async function wait(duration) {
+	await new Promise(resolve => { setTimeout(resolve, duration); });
+}
+
+
+/**
+ * Resolve a promise with a timeout.
+ *
+ * @param {Promise} promise - Promise to wait for.
+ * @param {number} time - Maximum time im milliseconds to wait for.
+ * @param {*=} timeoutResult - Value to return if the operation timed out.
+ */
+async function timeout(promise, time, timeoutResult) {
+	let timer;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise(resolve => {
+				timer = setTimeout(() => resolve(timeoutResult), time);
+			}),
+		]);
+
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
 module.exports = {
 	basicType,
+	wait,
+	timeout,
 };

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -411,17 +411,8 @@ messages.assignInstanceCommand = new Request({
 	permission: "core.instance.assign",
 	requestProperties: {
 		"instance_id": { type: "integer" },
-		"slave_id": { type: "integer" },
+		"slave_id": { type: ["integer", "null"] },
 	},
-});
-
-messages.assignInstance = new Request({
-	type: "assign_instance",
-	links: ["master-slave"],
-	requestProperties: {
-		"serialized_config": { type: "object" },
-	},
-	forwardTo: "instance",
 });
 
 messages.startInstance = new Request({
@@ -655,6 +646,44 @@ messages.deleteUser = new Request({
 	},
 });
 
+
+// Internal requests
+messages.updateInstances = new Request({
+	type: "update_instances",
+	links: ["slave-master"],
+	requestProperties: {
+		"instances": {
+			type: "array",
+			items: {
+				type: "object",
+				additionalProperties: false,
+				required: ["serialized_config", "status"],
+				properties: {
+					"serialized_config": { type: "object" },
+					"status": { enum: [
+						"stopped", "starting", "running", "creating_save", "exporting_data",
+					]},
+				},
+			},
+		},
+	},
+});
+
+messages.assignInstance = new Request({
+	type: "assign_instance",
+	links: ["master-slave"],
+	requestProperties: {
+		"serialized_config": { type: "object" },
+	},
+	forwardTo: "instance",
+});
+
+messages.unassignInstance = new Request({
+	type: "unassigne_instance",
+	links: ["master-slave"],
+	forwardTo: "instance",
+});
+
 messages.getMetrics = new Request({
 	type: "get_metrics",
 	links: ["master-slave", "slave-instance"],
@@ -843,27 +872,6 @@ messages.instanceStatusChanged = new Event({
 		"status": { enum: [
 			"stopped", "starting", "running", "creating_save", "exporting_data",
 		]},
-	},
-});
-
-messages.updateInstances = new Event({
-	type: "update_instances",
-	links: ["slave-master"],
-	eventProperties: {
-		"instances": {
-			type: "array",
-			items: {
-				type: "object",
-				additionalProperties: false,
-				required: ["serialized_config", "status"],
-				properties: {
-					"serialized_config": { type: "object" },
-					"status": { enum: [
-						"stopped", "starting", "running", "creating_save", "exporting_data",
-					]},
-				},
-			},
-		},
 	},
 });
 

--- a/packages/lib/plugin.js
+++ b/packages/lib/plugin.js
@@ -192,6 +192,10 @@ class BaseInstancePlugin {
 	 * @param {string} event.name - Name of the player that joined/left.
 	 */
 	async onPlayerEvent(event) { }
+
+	async sendRcon(message, expectEmpty) {
+		return await this.instance.sendRcon(message, expectEmpty, this.info.name);
+	}
 }
 
 /**

--- a/packages/lib/prometheus.js
+++ b/packages/lib/prometheus.js
@@ -1,5 +1,121 @@
+/**
+ * Asynchronous Prometheus client
+ *
+ * Prometheus client for exposing metrics to a Prometheus server based on
+ * (possibly) asynchronous callbacks.  This library was developed as a
+ * replacement for prom-client in Clusterio due to the lack of callbacks on
+ * metric collections in prom-client.
+ *
+ * The ordinary use case of instrumenting a code base should be covered by
+ * {@link module:lib/prometheus.Counter}, {@link
+ * module:lib/prometheus.Gauge}, {@link module:lib/prometheus.Histogram} and
+ * {@link module:lib/prometheus.exposition}.  Note that the summary
+ * collector is not implemented.  See documentation for each of the listed
+ * interfaces for more information.
+ *
+ * @example
+ * const { Counter, exposition } = require("@clusterio/lib/prometheus");
+ *
+ * // Collectors are by default registered to the default collector regitry.
+ * const totalRequests = new Counter(
+ *     "app_request_count_total",
+ *     "Total requests handled.",
+ * );
+ *
+ * function handleRequest(...) {
+ *     // Do stuff
+ *     totalRequests.inc();
+ * }
+ *
+ * // Code handling the /metrics HTTP request, here shown for express
+ * // but any http framework may be used
+ * const app = require("express")();
+ * async function getMetrics(req, res) {
+ *     // By default exposition uses the default collector registry
+ *     let text = await exposition();
+ *     res.set("Content-Type", exposition.contentType);
+ *     res.send(text);
+ * }
+ * app.get("/metrics", (req, res, next) => getMetrics(req, res).catch(next));
+ * app.listen(9100);
+ * @module lib/prometheus
+ */
 "use strict";
+
+/**
+ * Result from collecting a {@link module:lib/prometheus.Collector}
+ * @typedef {Object} CollectorResult
+ * @property {module:lib/prometheus.Metric} metric -
+ *     Metric collected.
+ * @property {Map<string, Map<string, number>>} samples -
+ *     Mapping of metric suffix to mapping of label keys to values
+ *     collected.  For normal metrics the first level contains a single
+ *     entry under the empty string as key.  If the metric does not have
+ *     labels the second level also contains a single entry under the empty
+ *     string as a key.
+ *
+ * @example <caption>Simple Metric</caption>
+ * let result = {
+ *     metric: new Metric("count", "simple_total_count", "A simple counter"),
+ *     samples: new Map([
+ *         ["", new Map([
+ *             ["", 123],
+ *         ])],
+ *     ]),
+ * }
+ *
+ * @example <caption>Labeled Metric</caption>
+ * let result = {
+ *     metric: new Metric(
+ *         "count", "labeled_total_count", "A labeled counter", ["a", "b"]
+ *     ),
+ *     samples: new Map([
+ *         ["", new Map([
+ *             ['a="1",b="3"', 123],
+ *             ['a="2",b="1"', 34],
+ *             ['a="2",b="9"', 7],
+ *         ])],
+ *     ]),
+ * }
+ *
+ * @example <caption>Histogram Metric</caption>
+ * let result = {
+ *     metric: new Metric(
+ *         "histogram", "histogram_size", "A histogram of sizes"
+ *     ),
+ *     samples: new Map([
+ *         ["_bucket", new Map([
+ *             ['le="1"', 1],
+ *             ['le="5"', 4],
+ *             ['le="+Inf"', 5],
+ *         ])],
+ *         ["_sum", new Map([
+ *             ["", 48],
+ *         ])],
+ *         ["_count", new Map([
+ *             ["", 5],
+ *         ])],
+ *     ]),
+ * }
+ */
+
+/**
+ * Represents a collectable metric
+ *
+ * Used in implementing collectors in order to validate the name, help text
+ * and labels attached to the collector.
+ * @static
+ */
 class Metric {
+	/**
+	 * @param {string} type -
+	 *     Metric type, should be one of `counter`, `gauge`, `histogram`,
+	 *     `summary` or `untyped`,
+	 * @param {string} name - Name of the metric.
+	 * @param {string} help - Help text for the metric.
+	 * @param {Array<string>} labels -
+	 * @param {Array<string>} _reserved_labels -
+	 */
 	constructor(type, name, help, labels = [], _reserved_labels = []) {
 		if (typeof name !== "string") {
 			throw new Error("Expected name to be a string");
@@ -21,25 +137,82 @@ class Metric {
 			}
 		}
 
+		/**
+		 * Name of the metric
+		 * @type {string}
+		 */
 		this.name = name;
+
+		/**
+		 * Help text for the metric
+		 * @type {string}
+		 */
 		this.help = help;
+
+		/**
+		 * Metric type, should be one of `counter`, `gauge`, `histogram`,
+		 * `summary` or `untyped`.
+		 * @type {string}
+		 */
 		this.type = type;
+
+		/**
+		 * Labels for this metric.
+		 * @type {Array<string>}
+		 */
 		this.labels = labels;
 	}
 }
 
+/**
+ * The default registry which collectors are regististered to.
+ * @type {module:lib/prometheus.CollectorRegistry}
+ * @static
+ */
 let defaultRegistry;
 
+/**
+ * Base class for all collectors
+ *
+ * This servers mostly as a conceptual base for all collectors, the only
+ * feature implemented here is registring to the default registry on
+ * construction.  If you want to implement a custom collector you most
+ * likely want to base it on {@link module:lib/prometheus.LabeledCollector}
+ * instead.
+ *
+ * @static
+ */
 class Collector {
+	/**
+	 * Create collector
+	 *
+	 * @param {boolean=} register -
+	 *     Whether to register this collector to the default registry.
+	 */
 	constructor(register = true) {
 		if (register) {
 			defaultRegistry.register(this);
 		}
 	}
 
+	/**
+	 * Retrieve metric data from this collctor.
+	 *
+	 * Called by {@link module:lib/prometheus.CollectorRegistry} to gather
+	 * the metric data this Collector exports.
+	 *
+	 * @returns {*} Async iterator of {@link CollectorResult}.
+	 */
 	async* collect() { }
 }
 
+/**
+ * Escapes a label value in accordance with the text exposition format
+ *
+ * @param {string} value - Value to escape.
+ * @returns {string} escaped value with \, ", and newline escaped.
+ * @private
+ */
 function escapeLabelValue(value) {
 	return value
 		.replace(/\\/g, "\\\\")
@@ -48,6 +221,15 @@ function escapeLabelValue(value) {
 	;
 }
 
+/**
+ * Convert label expression to unique string
+ *
+ * @param {Array<(string|Object<string, string>)>} labels -
+ *     label values to compute key for.
+ * @param {Array<string>} metricLabels - labels defined for the metric.
+ * @returns {string} computed key
+ * @private
+ */
 function labelsToKey(labels, metricLabels) {
 	let items = [];
 	if (labels.length === 1 && typeof labels[0] === "object") {
@@ -122,7 +304,40 @@ function removeMatchingLabels(mapping, labels) {
 	}
 }
 
+/**
+ * Base class for implementing labeled collectors
+ *
+ * Provides the scaffolding for creating labled collectors where each label
+ * set is a child to the collector that can be retrieved with the .labels()
+ * method.
+ *
+ * @extends module:lib/prometheus.Collector
+ * @static
+ */
 class LabeledCollector extends Collector {
+	/**
+	 * Create optionally labeled collector
+	 *
+	 * @param {string} type - Type for metric.
+	 * @param {string} name - Name of the metric.
+	 * @param {string} help - Help text for metric.
+	 * @param {Object} options - options for collector.
+	 * @param {Array<string>=} options.labels -
+	 *     Labels for this metric, defaults to no labels.
+	 * @param {Array<string>=} options._reservedLabels -
+	 *     Labels which may not be used.  Is passed to Metric constructor.
+	 * @param {boolean=} options.register -
+	 *     If true registers this collector with the default registry.
+	 *     Defaults to true.
+	 * @param {function()=} options.callaback -
+	 *     Possibly async function that is called before the metric is
+	 *     collected.
+	 * @param {
+	 *     function(module:lib/prometheus.LabeledCollector,string)
+	 * } childClass -
+	 *     Constructor taking instance of collector and label key as
+	 *     arguments and returns a child instance.
+	 */
 	constructor(type, name, help, options, childClass) {
 		let labels = [];
 		let reservedLabels = [];
@@ -153,6 +368,23 @@ class LabeledCollector extends Collector {
 		this._childClass = childClass;
 	}
 
+	/**
+	 * Access child collector with the given labels.
+	 *
+	 * Creates a labeled child collector for this collector.  The child
+	 * supports the methods of Collector for modifying and querying the
+	 * value of the metric.
+	 *
+	 * Once created, a value is initialized for the label values used and
+	 * exported from the collector until it's removed explicitly with
+	 * the .remove() or .removeAll() methods.
+	 *
+	 * @param {...string|Object<string,string>} labels -
+	 *     A string value passed for each label defined on the metric in the
+	 *     same order as the labels option given to the collector, or an
+	 *     object mapping label name to label value.
+	 * @returns {*} Child collector for the given labels.
+	 */
 	labels(...labels) {
 		let key = labelsToKey(labels, this.metric.labels);
 		let child = this._children.get(key);
@@ -163,6 +395,18 @@ class LabeledCollector extends Collector {
 		return child;
 	}
 
+	/**
+	 * Remove child collector and data for a given label set
+	 *
+	 * Remove the child collector and the value it stores from the collector
+	 * itself.  This will remove the entry exported for the given labels.
+	 *
+	 * @param {...string|Object<string,string>} labels -
+	 *     A string value passed for each label defined on the metric in the
+	 *     same order as the labels option given to the collector, or an
+	 *     object mapping label name to label value.
+	 * @returns {string} key for labels to remove (for use in subclasses).
+	 */
 	remove(...labels) {
 		let key = labelsToKey(labels, this.metric.labels);
 		if (key === "") {
@@ -172,6 +416,18 @@ class LabeledCollector extends Collector {
 		return key;
 	}
 
+	/**
+	 * Remove child collectors matching a partial label set
+	 *
+	 * Removes all child collecters which has labels matching the ones given
+	 * in labels parameter, Unline .remove this can be a partial set of
+	 * labels and all child collectors with their stored values that shares
+	 * this set of labels will be removed.
+	 *
+	 * @param {Object<string,string>} labels -
+	 *     Object mapping with label name to label values that should be
+	 *     matches.
+	 */
 	removeAll(labels) {
 		if (!Object.keys(labels).length) {
 			throw new Error("labels cannot be empty");
@@ -180,6 +436,12 @@ class LabeledCollector extends Collector {
 		removeMatchingLabels(this._children, labels);
 	}
 
+	/**
+	 * Clear all labeles on this collector
+	 *
+	 * Clears all child collectors from this collector along with their
+	 * stored values.  This effectively removes all the exported values.
+	 */
 	clear() {
 		if (!this.metric.labels.length) {
 			throw new Error("Cannot clear unlabeled metric");
@@ -188,7 +450,40 @@ class LabeledCollector extends Collector {
 	}
 }
 
+/**
+ * Base class for implementing single value per label collectors
+ *
+ * @extends module:lib/prometheus.LabeledCollector
+ * @static
+ */
 class ValueCollector extends LabeledCollector {
+	/**
+	 * Create optionally labeled value collector
+	 *
+	 * @param {string} type - Type for metric.
+	 * @param {string} name - Name of the metric.
+	 * @param {string} help - Help text for metric.
+	 * @param {Object} options - options for collector.
+	 * @param {Array<string>=} options.labels -
+	 *     Labels for this metric, defaults to no labels.
+	 * @param {Array<string>=} options._reservedLabels -
+	 *     Labels which may not be used.  Is passed to Metric constructor.
+	 * @param {boolean=} options.register -
+	 *     If true registers this collector with the default registry.
+	 *     Defaults to true.
+	 * @param {function()=} options.callaback -
+	 *     Possibly async function that is called before the collector value
+	 *     is collected.
+	 * @param {
+	 *     function(
+	 *         new:module:lib/prometheus.ValueCollectorChild,
+	 *         module:lib/prometheus.LabeledCollector,
+	 *         string
+	 *     )
+	 * } childClass -
+	 *     Constructor taking instance of collector and label key as
+	 *     arguments and returns a child instance.
+	 */
 	constructor(type, name, help, options, childClass) {
 		super(type, name, help, options, childClass);
 
@@ -201,6 +496,12 @@ class ValueCollector extends LabeledCollector {
 		yield { metric: this.metric, samples: new Map([["", this._values]]) };
 	}
 
+	/**
+	 * Get the current value for this collector.
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 * @returns {number} value stored.
+	 */
 	get() {
 		return this._defaultChild.get();
 	}
@@ -221,6 +522,9 @@ class ValueCollector extends LabeledCollector {
 	}
 }
 
+/**
+ * Child collector representing the value of a single label set
+ */
 class ValueCollectorChild {
 	constructor(collector, key) {
 		this._values = collector._values;
@@ -229,12 +533,26 @@ class ValueCollectorChild {
 		this._values.set(key, 0);
 	}
 
+	/**
+	 * Returns the current value of label set
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 * @returns {number} value stored.
+	 */
 	get() {
 		return this._values.get(this._key);
 	}
 }
 
+/**
+ * Child counter holding the value for a single label set.
+ * @extends module:lib/prometheus~ValueCollectorChild
+ */
 class CounterChild extends ValueCollectorChild {
+	/**
+	 * Increment counter for label set
+	 * @param {number} value - Positive number to increment by.
+	 */
 	inc(value = 1) {
 		// Note: Inverted to also catch NaN
 		if (!(value >= 0)) {
@@ -245,51 +563,318 @@ class CounterChild extends ValueCollectorChild {
 	}
 }
 
+/**
+ * Basic increasing counter
+ *
+ * Stores and exports an optionally labeled counter metric.  This is one of
+ * the two basic building blocks for instrumenting code and represents a
+ * metric that can only increase in value, such as the total number of
+ * requests processed or total time spent processing requests.
+ *
+ * Counters should be created at module load time and referenced in the
+ * functions that increment them, for example:
+ *
+ * ```js
+ * const totalRequests = new Counter(
+ *     "app_request_count_total",
+ *     "Total requests handled.",
+ * );
+ *
+ * function handleRequest(...) {
+ *     // Do stuff
+ *     totalRequests.inc();
+ * }
+ * ```
+ *
+ * The `totalRequests` counter will register with the default registry and
+ * provided exposition is set up (see {@link
+ * module:lib/prometheus.exposition}) the counter will be exported to
+ * Prometheus starting out with a value of 0.  And that is all there is to
+ * it.
+ *
+ * It is sometimes useful however to divide a metric up into diffrent
+ * sections, for example to have a different count for each endpoint handled
+ * or one count for successfull requests and one for requests resulting in
+ * an error.  For this Prometheus provides labels, and to use them pass the
+ * labels option as the third argument to Counter:
+ *
+ * ```js
+ * const totalRequests = new Counter(
+ *     "app_request_count_total",
+ *     "Total requests handled.",
+ *     { labels: ["endpoint", "status"] },
+ * );
+ *
+ * function handleRequest(endpoint, ...) {
+ *     let status = "ok";
+ *     try {
+ *         // Do stuff
+ *     } catch (err) {
+ *         status = "err";
+ *     } finally {
+ *         totalRequests.labels(endpoint, status).inc();
+ *     }
+ * }
+ * ```
+ *
+ * When using labels the counter no longer gets a default value and it's no
+ * longer possible to use the `.inc()` method on the counter itself, the
+ * `.labels()` method has to be invoked with the values for the labels
+ * defined.  `.labels()` returns a child counter for the label values given
+ * to it and this child can be operated on and cached for performance if
+ * that is critical.
+ *
+ * The lack of a default value may cause issues with aggregating and
+ * querying the counter values in Prometheus.  It is therefore recommended
+ * where possible to initialize all possible combinations of label values
+ * that will be used.  This is done by calling `.labels()` for each
+ * combination, for example:
+ *
+ * ```js
+ * for (let endpoint of allEndpoints) {
+ *     for (let status of ["ok", "err"]) {
+ *         totalRequests.labels(endpoint, status);
+ *     }
+ * }
+ * ```
+ *
+ * Note that every combination of label values used creates a new time
+ * series to be stored and processed.  You should carefully evaluate which
+ * labels you actually need as resource usage for a metric increases
+ * exponentially with the number of labels used.
+ *
+ * @extends module:lib/prometheus.ValueCollector
+ * @static
+ */
 class Counter extends ValueCollector {
+	/**
+	 * Create optionally labeled counter
+	 *
+	 * @param {string} name - Name of the metric.
+	 * @param {string} help - Help text for metric.
+	 * @param {Object=} options - options for collector.
+	 * @param {Array<string>=} options.labels -
+	 *     Labels for this metric, defaults to no labels.
+	 * @param {boolean=} options.register -
+	 *     If true registers this collector with the default registry.
+	 *     Defaults to true.
+	 * @param {function()=} options.callaback -
+	 *     Possibly async function that is called when the metric is
+	 *     collected.
+	 */
 	constructor(name, help, options = {}) {
 		super("counter", name, help, options, CounterChild);
 	}
 
+	/**
+	 * Increment counter value
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 * @param {number} value - Positive number to increment by.
+	 */
 	inc(value = 1) {
 		this._defaultChild.inc(value);
 	}
 }
 
+/**
+ * Child gauge holding the value for a single label set.
+ * @extends module:lib/prometheus~ValueCollectorChild
+ */
 class GaugeChild extends ValueCollectorChild {
+	/**
+	 * Increment gague for label set
+	 *
+	 * @param {number} value - number to increment by.
+	 */
 	inc(value = 1) {
 		this._values.set(this._key, this._values.get(this._key) + value);
 	}
 
+	/**
+	 * Decrement gague for label set
+	 *
+	 * @param {number} value - number to decrease by.
+	 */
 	dec(value = 1) {
 		this._values.set(this._key, this._values.get(this._key) - value);
 	}
 
+	/**
+	 * Set gague for label set
+	 *
+	 * @param {number} value - number to set gauge to.
+	 */
 	set(value) {
 		this._values.set(this._key, value);
 	}
 
+	/**
+	 * Set to current Unix epoch time in seconds for label set
+	 */
 	setToCurrentTime() {
 		this._values.set(this._key, Date.now() / 1000);
 	}
 }
 
+/**
+ * Basic value metric
+ *
+ * Stores and exports an optionally labeled value metric.  This is one of
+ * the two basic building blocks for instrumenting code and represents a
+ * value that can both increase and decrease over time, such as the number
+ * of requests in-flight or the number of users in a database.
+ *
+ * Gauges should be created at module load time and referenced in the
+ * functions that modify them, for example:
+ *
+ * ```js
+ * const activeRequests = new Gauge(
+ *     "app_active_request_count",
+ *     "Number of requests in-flight.",
+ * );
+ *
+ * async function handleRequest(...) {
+ *     activeRequests.inc();
+ *     try {
+ *         // Do async stuff
+ *     } finally {
+ *         activeRequests.dec();
+ *     }
+ * }
+ * ```
+ *
+ * The `activeRequests` gauge will register with the default registry and
+ * provided exposition is set up (see {@link
+ * module:lib/prometheus.exposition}) the gauge will be exported to
+ * Prometheus starting out with a value of 0.
+ *
+ * Sometimes keeping track of the value measured is impractical or
+ * prohibitly expensive.  In those cases you can update the value
+ * of the collector as it's being collected for export with a callback
+ * function passed as one of the options.
+ *
+ * ```js
+ * const userCount = new Gauge(
+ *     "app_user_count",
+ *     "Number of users in the app.",
+ *     {
+ *         callback: async function() {
+ *             // Make sure this request can not take a long time to
+ *             // complete as that will cause the metrics gathering
+ *             // to time out.
+ *             userCount.set(await someApi.getUserCount());
+ *         },
+ *     },
+ * );
+ * ```
+ *
+ * Keep in mind the callbacks are executed one by one at the time the
+ * collectors are collected for the exposition given the Prometheus. The
+ * default timeout in Prometheus for a collection job is 10 seconds.   This
+ * means the callback completion time should be in the order of milliseconds
+ * to avoid having the time of many collectors add up to too much.
+ *
+ * Like with the Counter the Gauge also supports labels.  When using labels
+ * the methods for changing the value of the counter is not longer usable
+ * directly on the counter itself, instead a child counter with label values
+ * set has to be retrieved with the `.labels()` method.  For example:
+ *
+ * ```js
+ * const userCount = new Gauge(
+ *     "app_user_count",
+ *     "Number of users in the app",
+ *     {
+ *         labels: ["role"],
+ *         callback: async function() {
+ *             userCount.labels("system").set(await someApi.getSystemUserCount());
+ *             userCount.labels("admin").set(await someApi.getAdminUserCount());
+ *             userCount.labels("normal").set(await someApi.getNormalUserCount());
+ *         }
+ *     },
+ * );
+ * ```
+ *
+ * When using labels the gauge no longer gets a default value, and this may
+ * cause issues with aggregating and querying the gauge values in
+ * Prometheus.  This is not an issue with the example shown above as all
+ * label combinations used are given a value when the gauge is collected.
+ * But if these labeled values were calculated through some other means
+ * dynamically there may be cases where values for timeseries that are
+ * occasionally used are missing.  When dynamically setting labels it is
+ * recommended where possible to initialize all possible combinations of
+ * label values that will be used.  This is done by calling `.labels()` for
+ * each combination, for example:
+ *
+ * ```js
+ * for (let role of ["system", "admin", "normal") {
+ *     userCount.labels(role);
+ * }
+ * ```
+ *
+ * Note that every combination of label values used creates a new time
+ * series to be stored and processed.  You should carefully evaluate which
+ * labels you actually need as resource usage for a metric increases
+ * exponentially with the number of labels used.
+ *
+ * @extends module:lib/prometheus.ValueCollector
+ * @static
+ */
 class Gauge extends ValueCollector {
+	/**
+	 * Create optionally labeled gauge
+	 *
+	 * @param {string} name - Name of the metric.
+	 * @param {string} help - Help text for metric.
+	 * @param {Object=} options - options for collector.
+	 * @param {Array<string>=} options.labels -
+	 *     Labels for this metric, defaults to no labels.
+	 * @param {boolean=} options.register -
+	 *     If true registers this collector with the default registry.
+	 *     Defaults to true.
+	 * @param {function()=} options.callaback -
+	 *     Possibly async function that is called when the metric is
+	 *     collected.
+	 */
 	constructor(name, help, options = {}) {
 		super("gauge", name, help, options, GaugeChild);
 	}
 
+	/**
+	 * Increment gague value
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 * @param {number} value - number to increment by.
+	 */
 	inc(value = 1) {
 		this._defaultChild.inc(value);
 	}
 
+	/**
+	 * Decrement gague value
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 * @param {number} value - number to decrease by.
+	 */
 	dec(value = 1) {
 		this._defaultChild.dec(value);
 	}
 
+	/**
+	 * Set gague value
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 * @param {number} value - number to set gauge to.
+	 */
 	set(value) {
 		this._defaultChild.set(value);
 	}
 
+	/**
+	 * Set to current Unix epoch time in seconds
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 */
 	setToCurrentTime() {
 		this._defaultChild.setToCurrentTime();
 	}
@@ -309,6 +894,9 @@ function formatBucketKey(bucket, key) {
 	return `${key === "" ? "" : `${key},`}le="${formatValue(bucket)}"`;
 }
 
+/**
+ * Child histogram holding the buckets for a single label set.
+ */
 class HistogramChild {
 	constructor(collector, key) {
 		this._bucketValues = collector._bucketValues;
@@ -328,6 +916,10 @@ class HistogramChild {
 		this._countValues.set(key, 0);
 	}
 
+	/**
+	 * Mapping of bucket upper bounds to count of observations for label set
+	 * @type {Map<number, number>}
+	 */
 	get buckets() {
 		return new Map(
 			[...this._bucketKeys].map(
@@ -336,14 +928,27 @@ class HistogramChild {
 		);
 	}
 
+	/**
+	 * Sum of all observations for label set
+	 * @type {number}
+	 */
 	get sum() {
 		return this._sumValues.get(this._key);
 	}
 
+	/**
+	 * Count of observations for label set
+	 * @type {number}
+	 */
 	get count() {
 		return this._countValues.get(this._key);
 	}
 
+	/**
+	 * Observe a given value and increment matching buckets for label set
+	 *
+	 * @param {number} value - number to count into histogram buckets.
+	 */
 	observe(value) {
 		for (let [bound, key] of this._bucketKeys) {
 			if (value <= bound) {
@@ -355,6 +960,13 @@ class HistogramChild {
 		this._countValues.set(this._key, this._countValues.get(this._key) + 1);
 	}
 
+	/**
+	 * Start a timer for observing a duration for label set
+	 *
+	 * @returns {function()}
+	 *     function that when called will store the duration in seconds from
+	 *     when the timer was started into the metric.
+	 */
 	startTimer() {
 		let start = process.hrtime.bigint();
 		return () => {
@@ -364,7 +976,101 @@ class HistogramChild {
 	}
 }
 
+/**
+ * Histogram metric
+ *
+ * Keeps track of observed values in a set of buckets in a similar vein to a
+ * histogram.  This is useful when you have a frequent operation that
+ * reports a metric that you want insight into the distribution of values
+ * for.  A common case for this is request duration, for example:
+ *
+ * ```js
+ * const requestDuration = new Histogram(
+ *     "app_request_duration_seconds",
+ *     "Time to process app requests",
+ * );
+ *
+ * async function handleRequest(...) {
+ *     const observeDuration = requestDuration.startTimer();
+ *     try {
+ *         // Do async stuff.
+ *     } finally {
+ *         observeDuration();
+ *     }
+ * }
+ * ```
+ *
+ * The default buckets used for the histogram is suitable for observing
+ * HTTP requests durations in seconds, and the `.startTimer()` method
+ * provides a convenient interface for adding observed durations to the
+ * histogram.  Other types values can be added to a histogram with the
+ * `.observe()` method.
+ *
+ * Like with the Counter and Gauge the Histogram collector also supports
+ * labels.  When using labels the methods for observing values into the
+ * histogram is not longer usable directly on the counter itself, instead a
+ * child histogram with label values set has to be retrieved with the
+ * `.labels()` method.  For example:
+ *
+ * ```js
+ * const requestDuration = new Histogram(
+ *     "app_request_duration_seconds",
+ *     "Time to process app requests",
+ *     { labels: ["endpoint"] }
+ * );
+ *
+ * async function handleRequest(endpoint, ...) {
+ *     const observeDuration = requestDuration.labels(endpoint).startTimer();
+ *     try {
+ *         // Do async stuff.
+ *     } finally {
+ *         observeDuration();
+ *     }
+ * }
+ * ```
+ *
+ * When using labels the histogram is no longer initalized with a default value, and this may
+ * cause issues with aggregating and querying the histogram in
+ * Prometheus.  When dynamically setting labels it is recommended where
+ * possible to initialize all possible combinations of label values that
+ * will be used.  This is done by calling `.labels()` for each combination,
+ * for example:
+ *
+ * ```js
+ * for (let endpoint of ["/status", "/api", ...) {
+ *     requestDuration.labels(endpoint);
+ * }
+ * ```
+ *
+ * Note that every combination of label values used creates a new time
+ * series for each bucket in the histogram to be stored and processed.
+ * (e.g., 10 buckets with 10 possible label combinations will result in 100
+ * time series being made.)  You should carefully evaluate which labels you
+ * actually need as resource usage for a metric increases exponentially with
+ * the number of labels used.
+ *
+ * @static
+ */
 class Histogram extends LabeledCollector {
+	/**
+	 * Create optionally labeled histogram
+	 *
+	 * @param {string} name - Name of the metric.
+	 * @param {string} help - Help text for metric.
+	 * @param {Object=} options - options for collector.
+	 * @param {Array<number>=} options.buckets -
+	 *     Buckets to use for the histogram.  This is an array of inclusive
+	 *     upper bounds.  Values observed will increment a bucket if it is
+	 *     less than or equal to the upper bound.
+	 * @param {Array<string>=} options.labels -
+	 *     Labels for this metric, defaults to no labels.
+	 * @param {boolean=} options.register -
+	 *     If true registers this collector with the default registry.
+	 *     Defaults to true.
+	 * @param {function()=} options.callaback -
+	 *     Possibly async function that is called when the metric is
+	 *     collected.
+	 */
 	constructor(name, help, options = {}) {
 		// These defaults are taken from the Python Prometheus client
 		let buckets = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, Infinity];
@@ -403,22 +1109,54 @@ class Histogram extends LabeledCollector {
 		};
 	}
 
+	/**
+	 * Mapping of bucket upper bounds to count of observations for label set
+	 *
+	 * Note: Only available if this is an unlabeled collector.
+	 * @type {Map<number,number>}
+	 */
 	get buckets() {
 		return this._defaultChild.buckets;
 	}
 
+	/**
+	 * Sum of all observations for label set
+	 *
+	 * Note: Only available if this is an unlabeled collector.
+	 * @type {number}
+	 */
 	get sum() {
 		return this._defaultChild.sum;
 	}
 
+	/**
+	 * Count of observations for label set
+	 *
+	 * Note: Only available if this is an unlabeled collector.
+	 * @type {number}
+	 */
 	get count() {
 		return this._defaultChild.count;
 	}
 
+	/**
+	 * Observe a given value and increment matching buckets
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 * @param {number} value - number to count into histogram buckets.
+	 */
 	observe(value) {
 		this._defaultChild.observe(value);
 	}
 
+	/**
+	 * Start a timer for observing a duration
+	 *
+	 * Note: Only works if this is an unlabeled collector.
+	 * @returns {function()}
+	 *     function that when called will store the duration in seconds from
+	 *     when the timer was started into the metric.
+	 */
 	startTimer() {
 		return this._defaultChild.startTimer();
 	}
@@ -450,31 +1188,89 @@ class Histogram extends LabeledCollector {
 		this._sumValues = new Map();
 		this._countValues = new Map();
 	}
+
+	/**
+	 * Helper function for generating linear bucket series
+	 *
+	 * Creates an array of numbers suitable for using as buckets to a
+	 * histogram.  The array returned contains `count` numbers starting at
+	 * `start` and with each subsequent number being equal to the previous
+	 * one plus `width`.
+	 *
+	 * @param {number} start - Number to start buckets at.
+	 * @param {number} width - Distance between ecah bucket.
+	 * @param {number} count - Number of buckets.
+	 * @returns {Array<number>} array of buckets.
+	 */
+	static linear(start, width, count) {
+		let buckets = [];
+		for (let i = 0; i < count; i++) {
+			buckets.push(start);
+			start += width;
+		}
+		return buckets;
+	}
+
+	/**
+	 * Helper function for generating exponential bucket series
+	 *
+	 * Creates an array of numbers suitable for using as buckets to a
+	 * histogram.  The array returned contains `count` numbers starting at
+	 * `start` and with each subsequent number being equal to the previous
+	 * multiplied with `factor`.
+	 *
+	 * @param {number} start - Number to start buckets at.
+	 * @param {number} factor - Ratio between each bucket.
+	 * @param {number} count - Number of buckets.
+	 * @returns {Array<number>} array of buckets.
+	 */
+	static exponential(start, factor, count) {
+		let buckets = [];
+		for (let i = 0; i < count; i++) {
+			buckets.push(start);
+			start *= factor;
+		}
+		return buckets;
+	}
 }
 
-Histogram.linear = function linear(start, width, count) {
-	let buckets = [];
-	for (let i = 0; i < count; i++) {
-		buckets.push(start);
-		start += width;
-	}
-	return buckets;
-};
-
-Histogram.exponential = function exponential(start, factor, count) {
-	let buckets = [];
-	for (let i = 0; i < count; i++) {
-		buckets.push(start);
-		start *= factor;
-	}
-	return buckets;
-};
-
+/**
+ * Collection of collectors
+ *
+ * Provides convienece methods for grouping collectors together and
+ * gathering the metrics from all of the contained collectors.  By default
+ * collectors are registered and collected from the default registry so
+ * using this is usually not necessary.
+ *
+ * The basic way to use a custom registry is to create Collectors without
+ * registring them to the default registry and then adding them to your own
+ * registry, for example:
+ *
+ * ```js
+ * const myRegistry = new CollectorRegistry();
+ * const myCounter = new Counter( "a_counter", "A counter.", { register: false });
+ * myRegistry.register(myCounter);
+ *
+ * // In the /metrics HTTP request handler
+ * let text = await exposition(myRegistry.collect());
+ * ```
+ *
+ * The same collector can be registered to multiple registries.  This may be
+ * used to implement responding with different sets of metrics depending on
+ * what is requested.
+ *
+ * @static
+ */
 class CollectorRegistry {
 	constructor() {
 		this.collectors = [];
 	}
 
+	/**
+	 * Collect metrics from all registered collectors.
+	 *
+	 * @returns {*} Async iterator of {@link CollectorResult}.
+	 */
 	async* collect() {
 		for (let collector of this.collectors) {
 			for await (let result of collector.collect()) {
@@ -483,19 +1279,29 @@ class CollectorRegistry {
 		}
 	}
 
-	register(metric) {
-		let index = this.collectors.lastIndexOf(metric);
+	/**
+	 * Add collector to the registry.
+	 *
+	 * @param {lib/prometheus.Collector} collector - Collector to add.
+	 */
+	register(collector) {
+		let index = this.collectors.lastIndexOf(collector);
 		if (index !== -1) {
 			throw new Error(
 				"Collector is already registered in this registry."
 			);
 		}
 
-		this.collectors.push(metric);
+		this.collectors.push(collector);
 	}
 
-	unregister(metric) {
-		let index = this.collectors.lastIndexOf(metric);
+	/**
+	 * Remove collector from the registry.
+	 *
+	 * @param {lib/prometheus.Collector} collector - Collector to remove.
+	 */
+	unregister(collector) {
+		let index = this.collectors.lastIndexOf(collector);
 		if (index === -1) {
 			throw new Error(
 				"Collector is not registered in this registry."
@@ -539,6 +1345,41 @@ async function* expositionLines(resultsIterator) {
 	}
 }
 
+/**
+ * Serialize into Prometheus text exposition format
+ *
+ * Asynchronously collects metrics and converts them into the text based
+ * exposition format for Prometheus.  The collectors collected by default is
+ * taken from the default registry, but this can be overidden by passing a
+ * resultsIterator either from another registry or custom created.
+ *
+ * The resulting text from calling this method should be served to
+ * prometheus, typically by hosting an HTTP server in the app and responding
+ * to the /metrics endpoint.  See example below for how this is done with
+ * express.js.
+ *
+ * @example
+ * const app = require("express")();
+ * async function getMetrics(req, res) {
+ *     // By default exposition uses the default collector registry
+ *     let text = await exposition();
+ *     res.set("Content-Type", exposition.contentType);
+ *     res.send(text);
+ * }
+ * app.get("/metrics", (req, res, next) => getMetrics(req, res).catch(next));
+ * app.listen(9100);
+ *
+ * @param {*} resultsIterator -
+ *     Asynchronously itreable of {@link CollectorResult} results to create
+ *     exposition for.  Defaults to collecting results from {@link
+ *     module:lib/prometheus.defaultRegistry}.
+ * @returns {string} Prometheus exposition.
+ *
+ * @property {string} exposition.contentType
+ * HTTP Content-Type for the exposition format that's implemented
+ *
+ * @static
+ */
 async function exposition(resultsIterator = defaultRegistry.collect()) {
 	let lines = "";
 	for await (let line of expositionLines(resultsIterator)) {
@@ -547,9 +1388,26 @@ async function exposition(resultsIterator = defaultRegistry.collect()) {
 	return lines;
 }
 
-// HTTP Content-Type for the exposition format that's implemented
 exposition.contentType = "text/plain; version=0.0.4";
 
+/**
+ * Serialize CollectorResult into a plain object
+ *
+ * Converts a {@link module:lib/prometheus~CollectorResult} into a plain
+ * object form that can be stringified to JSON.
+ *
+ * @param {module:lib/prometheus~CollectorResult} result -
+ *     Result to serialize into plain object form.
+ * @param {Object} options - Options for controlling the serialization.
+ * @param {string} options.addLabels -
+ *     Additional labels to append to each value.  This may be used if
+ *     multiple sources are combined have the same metric and a qualifier is
+ *     needed to make sure the label sets are unique.
+ * @param {string} options.metricName - Override metric name of the result.
+ * @param {string} options.metricHelp - Override metric help of the result.
+ * @returns {Object} plain object form of the result.
+ * @static
+ */
 function serializeResult(result, options = {}) {
 	let addLabels = null;
 	let metricName = result.metric.name;
@@ -598,6 +1456,15 @@ function serializeResult(result, options = {}) {
 	};
 }
 
+/**
+ * Deserialize CollectorResult from plain object
+ *
+ * Reverse counterpart to {@link module:lib/prometheus.serializeResult}.
+ *
+ * @param {Object} serializedResult - Previously serialized result object.
+ * @returns {module:lib/prometheus~CollectorResult} deserialized result.
+ * @static
+ */
 function deserializeResult(serializedResult) {
 	return {
 		metric: new Metric(
@@ -614,6 +1481,10 @@ function deserializeResult(serializedResult) {
 	};
 }
 
+/**
+ * Default collectors provided by this library
+ * @type {Object<string, module:lib/prometheus.Collector>}
+ */
 let defaultCollectors = {};
 defaultCollectors.processCpuSecondsTotal = new Gauge(
 	"process_cpu_seconds_total",
@@ -659,6 +1530,7 @@ module.exports = {
 	Histogram,
 	CollectorRegistry,
 	Collector,
+	LabeledCollector,
 	ValueCollector,
 	Metric,
 

--- a/packages/lib/prometheus.js
+++ b/packages/lib/prometheus.js
@@ -275,6 +275,10 @@ function labelsToKey(labels, metricLabels) {
 		}
 	}
 
+	if (items.length === 1) {
+		return items[0];
+	}
+
 	return items.join(",");
 }
 

--- a/packages/lib/prometheus.js
+++ b/packages/lib/prometheus.js
@@ -206,6 +206,7 @@ class Collector {
 	async* collect() { }
 }
 
+const labelEscapesChars = /[\\\n\"]/;
 /**
  * Escapes a label value in accordance with the text exposition format
  *
@@ -214,6 +215,9 @@ class Collector {
  * @private
  */
 function escapeLabelValue(value) {
+	if (!labelEscapesChars.test(value)) {
+		return value;
+	}
 	return value
 		.replace(/\\/g, "\\\\")
 		.replace(/\n/g, "\\n")

--- a/packages/master/master.js
+++ b/packages/master/master.js
@@ -168,8 +168,17 @@ async function getMetrics(req, res, next) {
 
 			} else {
 				// Merge metrics received by multiple slaves
-				let stored = resultMap.get(result.metric.name);
-				stored.samples.push(...result.samples);
+				let receivedSamples = new Map(result.samples);
+				for (let [suffix, suffixSamples] of resultMap.get(result.metric.name).samples) {
+					if (receivedSamples.has(suffix)) {
+						suffixSamples.push(...receivedSamples.get(suffix));
+						receivedSamples.delete(suffix);
+					}
+				}
+
+				for (let entry of receivedSamples) {
+					result.samples.push(entry);
+				}
 			}
 		}
 	}

--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -124,6 +124,9 @@ class Instance extends libLink.Link{
 			} else if (group.name === "factorio" && field === "enable_whitelist") {
 				this.updateFactorioWhitelist(group.get(field)).finally(hook);
 			} else {
+				if (group.name === "factorio" && field === "max_concurrent_commands") {
+					this.server.maxConcurrentCommands = group.get(field);
+				}
 				hook();
 			}
 		};
@@ -137,6 +140,7 @@ class Instance extends libLink.Link{
 			enableWhitelist: this.config.get("factorio.enable_whitelist"),
 			verboseLogging: this.config.get("factorio.verbose_logging"),
 			stripPaths: this.config.get("factorio.strip_paths"),
+			maxConcurrentCommands: this.config.get("factorio.max_concurrent_commands"),
 		};
 
 		this._status = "stopped";

--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -819,7 +819,7 @@ class InstanceConnection extends libLink.Link {
 		let instanceConnection = this.slave.instanceConnections.get(instanceId);
 		if (!instanceConnection) {
 			// Instance is probably on another slave
-			return await request.send(this.slave, message.data);
+			return await this.forwardRequestToMaster(message, request);
 		}
 
 		if (request.plugin && !instanceConnection.plugins.has(request.plugin)) {
@@ -835,7 +835,7 @@ class InstanceConnection extends libLink.Link {
 		let instanceConnection = this.slave.instanceConnections.get(instanceId);
 		if (!instanceConnection) {
 			// Instance is probably on another slave
-			await this.slave.forwardEventToMaster(message, event);
+			await this.forwardEventToMaster(message, event);
 			return;
 		}
 		if (event.plugin && !instanceConnection.plugins.has(event.plugin)) { return; }

--- a/packages/web_ui/src/util/websocket.jsx
+++ b/packages/web_ui/src/util/websocket.jsx
@@ -49,6 +49,10 @@ export class Control extends libLink.Link {
 		}
 
 		this.instanceOutputHandlers = new Map();
+
+		this.connector.on("connect", () => {
+			this.updateInstanceOutputSubscriptions().catch(console.error);
+		});
 	}
 
 	async instanceOutputEventHandler(message) {

--- a/plugins/global_chat/instance.js
+++ b/plugins/global_chat/instance.js
@@ -33,7 +33,7 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 	async chatEventHandler(message) {
 		// TODO check if cross server chat is enabled
 		let content = `[${message.data.instance_name}] ${removeTags(message.data.content)}`;
-		await this.instance.server.sendRcon(`/sc game.print('${libLuaTools.escapeString(content)}')`, true);
+		await this.sendRcon(`/sc game.print('${libLuaTools.escapeString(content)}')`, true);
 	}
 
 	sendChat(message) {

--- a/plugins/research_sync/instance.js
+++ b/plugins/research_sync/instance.js
@@ -29,7 +29,7 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 
 	async progressEventHandler(message) {
 		let techsJson = libLuaTools.escapeString(JSON.stringify(message.data.technologies));
-		await this.instance.server.sendRcon(`/sc research_sync.update_progress("${techsJson}")`, true);
+		await this.sendRcon(`/sc research_sync.update_progress("${techsJson}")`, true);
 	}
 
 	async researchFinished(tech) {
@@ -38,13 +38,13 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 
 	async finishedEventHandler(message) {
 		let { name, level, researched } = message.data;
-		await this.instance.server.sendRcon(
+		await this.sendRcon(
 			`/sc research_sync.research_technology("${libLuaTools.escapeString(name)}", ${level})`, true
 		);
 	}
 
 	async onStart() {
-		let dumpJson = await this.instance.server.sendRcon("/sc research_sync.dump_technologies()");
+		let dumpJson = await this.sendRcon("/sc research_sync.dump_technologies()");
 		let techsToSend = [];
 		let instanceTechs = new Map();
 		for (let tech of JSON.parse(dumpJson)) {
@@ -74,7 +74,7 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 
 		if (techsToSync.length) {
 			let syncJson = libLuaTools.escapeString(JSON.stringify(techsToSync));
-			await this.instance.server.sendRcon(`/sc research_sync.sync_technologies("${syncJson}")`, true);
+			await this.sendRcon(`/sc research_sync.sync_technologies("${syncJson}")`, true);
 		}
 	}
 }

--- a/plugins/statistics_exporter/instance.js
+++ b/plugins/statistics_exporter/instance.js
@@ -30,7 +30,7 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 	}
 
 	async gatherMetrics() {
-		let string = await this.instance.server.sendRcon("/sc statistics_exporter.export()");
+		let string = await this.sendRcon("/sc statistics_exporter.export()");
 		let stats;
 		try {
 			stats = JSON.parse(string);

--- a/plugins/subspace_storage/instance.js
+++ b/plugins/subspace_storage/instance.js
@@ -22,7 +22,7 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 
 	async onStart() {
 		this.pingId = setInterval(() => {
-			this.instance.server.sendRcon(
+			this.sendRcon(
 				"/sc __subspace_storage__ global.ticksSinceMasterPinged = 0", true
 			).catch(unexpectedError);
 		}, 5000);
@@ -30,7 +30,7 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 		let response = await this.info.messages.getStorage.send(this.instance);
 		// TODO Diff with dump of invdata produce minimal command to sync
 		let itemsJson = libLuaTools.escapeString(JSON.stringify(response.items));
-		await this.instance.server.sendRcon(`/sc __subspace_storage__ UpdateInvData("${itemsJson}", true)`, true);
+		await this.sendRcon(`/sc __subspace_storage__ UpdateInvData("${itemsJson}", true)`, true);
 	}
 
 	onExit() {
@@ -68,7 +68,7 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 		}
 
 		let itemsJson = libLuaTools.escapeString(JSON.stringify(response.items));
-		await this.instance.server.sendRcon(`/sc __subspace_storage__ Import("${itemsJson}")`, true);
+		await this.sendRcon(`/sc __subspace_storage__ Import("${itemsJson}")`, true);
 	}
 
 	// combinator signals ---------------------------------------------------------
@@ -87,7 +87,7 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 		items.push(["signal-unixtime", Math.floor(Date.now()/1000)]);
 
 		let itemsJson = libLuaTools.escapeString(JSON.stringify(items));
-		await this.instance.server.sendRcon(`/sc __subspace_storage__ UpdateInvData("${itemsJson}")`, true);
+		await this.sendRcon(`/sc __subspace_storage__ UpdateInvData("${itemsJson}")`, true);
 	}
 }
 

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -1,5 +1,6 @@
 "use strict";
 const assert = require("assert").strict;
+const hrtime = process.hrtime.bigint;
 
 const libHelpers = require("@clusterio/lib/helpers");
 
@@ -13,6 +14,32 @@ describe("lib/helpers", function() {
 			assert.equal(libHelpers.basicType([1, 2]), "array");
 			assert.equal(libHelpers.basicType(7), "number");
 			assert.equal(libHelpers.basicType({ a: 1 }), "object");
+		});
+	});
+
+	describe("wait", function() {
+		it("should wait the approximate amount of time given", async function() {
+			let startNs = hrtime();
+			await libHelpers.wait(100);
+			let duration = Number(hrtime() - startNs) / 1e6;
+
+			assert(duration > 90 && duration < 110, `duration waited (${duration}ms) 10% of expected (100ms)`);
+		});
+	});
+
+	describe("timeout", function() {
+		it("should return the result of an already resolved promise", async function() {
+			assert.equal(await libHelpers.timeout(Promise.resolve("value"), 10, "timeout"), "value");
+		});
+		it("should return the result of the promise if received before timeout", async function() {
+			assert.equal(await libHelpers.timeout(
+				(async () => { await libHelpers.wait(10); return "value"; })(), 20, "timeout"
+			), "value");
+		});
+		it("should return the timeoutResult if not received before timeout", async function() {
+			assert.equal(await libHelpers.timeout(
+				(async () => { await libHelpers.wait(20); return "value"; })(), 10, "timeout"
+			), "timeout");
 		});
 	});
 });

--- a/test/lib/prometheus.js
+++ b/test/lib/prometheus.js
@@ -200,7 +200,194 @@ describe("lib/prometheus", function() {
 		});
 	});
 
+	describe("class Histogram", function() {
+		let histogram;
+		let labeledHistogram;
+		beforeEach(function() {
+			histogram = new prometheus.Histogram(
+				"test", "Help", { register: false, buckets: [1, 2, 3, 4, Infinity] }
+			);
+			labeledHistogram = new prometheus.Histogram(
+				"test", "Help", { register: false, buckets: [1, Infinity], labels: ["a", "b"] }
+			);
+		});
+
+		describe("constructor", function() {
+			it("should have buckets, sum and count initialized to 0", function() {
+				assert.deepEqual(
+					histogram.buckets,
+					new Map([[1, 0], [2, 0], [3, 0], [4, 0], [Infinity, 0]])
+				);
+				assert.equal(histogram.sum, 0);
+				assert.equal(histogram.count, 0);
+			});
+			it("should provide a default for buckets", function() {
+				histogram = new prometheus.Histogram(
+					"test", "help", { register: false }
+				);
+				assert(histogram._buckets.length, "no default buckets were made");
+			});
+			it("should add inifinity bucket if not present", function() {
+				histogram = new prometheus.Histogram(
+					"test", "help", { buckets: [1], register: false }
+				);
+				assert.deepEqual(histogram._buckets, [1, Infinity]);
+			});
+			it("should not mutate bucket option passed to it", function() {
+				let buckets = [1];
+				histogram = new prometheus.Histogram(
+					"test", "help", { buckets, register: false }
+				);
+				assert.deepEqual(buckets, [1]);
+			});
+			it("should throw on unrecoginzed option", function() {
+				assert.throws(
+					() => new prometheus.Histogram("test", "help", { invalid: 1 }),
+					new Error("Unrecognized option 'invalid'")
+				);
+			});
+			it("should throw on using le as label", function() {
+				assert.throws(() => {
+					let test = new prometheus.Histogram(
+						"test", "Help", { register: false, labels: ["le", "test"] }
+					);
+				}, new Error("Reserved label 'le'"));
+			});
+		});
+
+		describe(".observe()", function() {
+			it("should increment the appropriate bucket", function() {
+				histogram.observe(2);
+				assert.deepEqual(
+					histogram.buckets,
+					new Map([[1, 0], [2, 1], [3, 1], [4, 1], [Infinity, 1]])
+				);
+				assert.equal(histogram.sum, 2);
+				assert.equal(histogram.count, 1);
+
+				histogram.observe(4);
+				assert.deepEqual(
+					histogram.buckets,
+					new Map([[1, 0], [2, 1], [3, 1], [4, 2], [Infinity, 2]])
+				);
+				assert.equal(histogram.sum, 6);
+				assert.equal(histogram.count, 2);
+			});
+		});
+
+		describe(".startTimer()", function() {
+			it("should add observations when closure is called", function() {
+				let observeDuration = histogram.startTimer();
+				assert.equal(histogram.count, 0);
+				observeDuration();
+				assert.equal(histogram.count, 1);
+				observeDuration();
+				assert.equal(histogram.count, 2);
+			});
+		});
+
+		describe("static .linear()", function() {
+			it("should give back the appropriate buckets", function() {
+				let linear = prometheus.Histogram.linear;
+				assert.deepEqual(linear(1, 2, 3), [1, 3, 5]);
+				assert.deepEqual(linear(-1, 4, 3), [-1, 3, 7]);
+				assert.deepEqual(linear(1, 1, 4), [1, 2, 3, 4]);
+			});
+		});
+
+		describe("static .exponential()", function() {
+			it("should give back the appropriate buckets", function() {
+				let exponential = prometheus.Histogram.exponential;
+				assert.deepEqual(exponential(1, 2, 3), [1, 2, 4]);
+				assert.deepEqual(exponential(2, 10, 3), [2, 20, 200]);
+				assert.deepEqual(exponential(1, 1.5, 4), [1, 1.5, 2.25, 3.375]);
+			});
+		});
+
+		describe(".labels()", function() {
+			it("should initialize a value for the label set", function() {
+				labeledHistogram.labels({ a: "1", b: "2" });
+				assert(labeledHistogram._bucketValues.has('a="1",b="2",le="1"'), "bucket value not set");
+				assert(labeledHistogram._bucketValues.has('a="1",b="2",le="+Inf"'), "bucket value not set");
+				assert(labeledHistogram._sumValues.has('a="1",b="2"'), "sum value not set");
+				assert(labeledHistogram._countValues.has('a="1",b="2"'), "count value not set");
+
+				labeledHistogram.labels("4", "5");
+				assert(labeledHistogram._bucketValues.has('a="4",b="5",le="1"'), "bucket value not set");
+				assert(labeledHistogram._bucketValues.has('a="4",b="5",le="+Inf"'), "bucket value not set");
+				assert(labeledHistogram._sumValues.has('a="4",b="5"'), "sum value not set");
+				assert(labeledHistogram._countValues.has('a="4",b="5"'), "count value not set");
+			});
+			it("should return a child supporting the histogram methods", function() {
+				let child = labeledHistogram.labels({ a: "1", b: "2" });
+				void child.buckets;
+				void child.sum;
+				void child.count;
+				child.observe(2);
+				let observeDuration = child.startTimer();
+				observeDuration();
+				child = labeledHistogram.labels("7", "8");
+				void child.buckets;
+				void child.sum;
+				void child.count;
+				child.observe(2);
+				observeDuration = child.startTimer();
+				observeDuration();
+			});
+			it("should return the same child for the same labels", function() {
+				let child = labeledHistogram.labels("1", "2");
+				assert.equal(labeledHistogram.labels("1", "2"), child);
+				assert.equal(labeledHistogram.labels({ a: "1", b: "2" }), child);
+			});
+		});
+		describe(".remove()", function() {
+			it("should remove a label set created with .labels()", function() {
+				labeledHistogram.labels("1", "2");
+				labeledHistogram.remove("1", "2");
+				assert(!labeledHistogram._bucketValues.has('a="1",b="2",le="1"'), "bucket value not removed");
+				assert(!labeledHistogram._bucketValues.has('a="1",b="2",le="+Inf"'), "bucket value not removed");
+				assert(!labeledHistogram._sumValues.has('a="1",b="2"'), "sum value not removed");
+				assert(!labeledHistogram._countValues.has('a="1",b="2"'), "count value not removed");
+			});
+		});
+		describe(".removeAll()", function() {
+			it("should remove a label set created with .labels()", function() {
+				labeledHistogram.labels("1", "2");
+				labeledHistogram.labels("1", "3");
+				labeledHistogram.labels("4", "6");
+				labeledHistogram.removeAll({ a: "1" });
+				assert.deepEqual(
+					labeledHistogram._bucketValues,
+					new Map([['a="4",b="6",le="1"', 0], ['a="4",b="6",le="+Inf"', 0]])
+				);
+				assert.deepEqual(labeledHistogram._sumValues, new Map([['a="4",b="6"', 0]]));
+				assert.deepEqual(labeledHistogram._countValues, new Map([['a="4",b="6"', 0]]));
+			});
+		});
+		describe(".clear()", function() {
+			it("should remove all label sets created with .labels()", function() {
+				labeledHistogram.labels("1", "2");
+				labeledHistogram.labels("1", "3");
+				labeledHistogram.labels("4", "6");
+				labeledHistogram.clear();
+				assert(labeledHistogram._bucketValues.size === 0, "buckets were not cleared");
+				assert(labeledHistogram._sumValues.size === 0, "sums were not cleared");
+				assert(labeledHistogram._countValues.size === 0, "counts were not cleared");
+			});
+		});
+	});
+
 	describe("class ValueCollector", function() {
+		describe(".get()", function() {
+			it("should return the current value", function() {
+				let gauge = new prometheus.Gauge("test", "Help", { register: false });
+				gauge.set(11);
+				assert.equal(gauge.get(), 11);
+			});
+		});
+	});
+
+	describe("class LabeledCollector", function() {
 		describe("constructor", function() {
 			it("should throw on invalid metric name", function() {
 				for (let name of ["", " ", "0a", "$a"]) {
@@ -239,14 +426,6 @@ describe("lib/prometheus", function() {
 					() => new prometheus.Gauge("test", "help", { invalid: 1 }),
 					new Error("Unrecognized option 'invalid'")
 				);
-			});
-		});
-
-		describe(".get()", function() {
-			it("should return the current value", function() {
-				let gauge = new prometheus.Gauge("test", "Help", { register: false });
-				gauge.set(11);
-				assert.equal(gauge.get(), 11);
 			});
 		});
 
@@ -310,6 +489,7 @@ describe("lib/prometheus", function() {
 			it("should return the same child for the same labels", function() {
 				let child = gauge.labels("1", "2");
 				assert.equal(gauge.labels("1", "2"), child);
+				assert.equal(gauge.labels({ a: "1", b: "2" }), child);
 			});
 		});
 		describe(".remove()", function() {
@@ -393,8 +573,9 @@ describe("lib/prometheus", function() {
 					"collector did not give exactly one result"
 				);
 
+				let value = results[0].samples.get("").get("");
 				assert(
-					Math.abs(results[0].samples.get("") - Date.now() / 1000) < 1,
+					Math.abs(value - Date.now() / 1000) < 1,
 					"value set is not close to the current unix time"
 				);
 			});
@@ -413,7 +594,7 @@ describe("lib/prometheus", function() {
 					"collector did not give exactly one result"
 				);
 
-				let value = results[0].samples.get("");
+				let value = results[0].samples.get("").get("");
 				assert(
 					value < 5 && value > 0,
 					`process time is not between 0 and 5 seconds (${value})`
@@ -434,7 +615,7 @@ describe("lib/prometheus", function() {
 					"collector did not give exactly one result"
 				);
 
-				let value = results[0].samples.get("");
+				let value = results[0].samples.get("").get("");
 				assert(
 					value < 200e6 && value > 0,
 					`resident memory is not between 0 and 200 MB (${value})`
@@ -455,7 +636,7 @@ describe("lib/prometheus", function() {
 					"collector did not give exactly one result"
 				);
 
-				let value = results[0].samples.get("");
+				let value = results[0].samples.get("").get("");
 				assert(
 					value < 200e6 && value > 0,
 					`heap is not between 0 and 200 MB (${value})`
@@ -500,6 +681,59 @@ describe("lib/prometheus", function() {
 				'test{a="x",b="y"} 0\n'
 			);
 		});
+		it("should format histogram metrics", async function() {
+			let registry = new prometheus.CollectorRegistry();
+			let histogram = new prometheus.Histogram(
+				"test", "Help", { register: false, buckets: [1, 2, 3, 4] }
+			);
+			for (let value of [2, 2, 5, 2]) {
+				histogram.observe(value);
+			}
+			registry.register(histogram);
+			let exposition = await prometheus.exposition(registry.collect());
+			assert.equal(
+				exposition,
+				"# HELP test Help\n" +
+				"# TYPE test histogram\n" +
+				'test_bucket{le="1"} 0\n' +
+				'test_bucket{le="2"} 3\n' +
+				'test_bucket{le="3"} 3\n' +
+				'test_bucket{le="4"} 3\n' +
+				'test_bucket{le="+Inf"} 4\n' +
+				"test_sum 11\n" +
+				"test_count 4\n"
+			);
+		});
+		it("should format histogram metrics with labels", async function() {
+			let registry = new prometheus.CollectorRegistry();
+			let histogram = new prometheus.Histogram(
+				"test", "Help", { register: false, buckets: [1], labels: ["l"] }
+			);
+			for (let [value, label] of [[1, "a"], [2, "b"], [3, "b"]]) {
+				histogram.labels(label).observe(value);
+			}
+			histogram.labels("c");
+
+			registry.register(histogram);
+			let exposition = await prometheus.exposition(registry.collect());
+			assert.equal(
+				exposition,
+				"# HELP test Help\n" +
+				"# TYPE test histogram\n" +
+				'test_bucket{l="a",le="1"} 1\n' +
+				'test_bucket{l="a",le="+Inf"} 1\n' +
+				'test_bucket{l="b",le="1"} 0\n' +
+				'test_bucket{l="b",le="+Inf"} 2\n' +
+				'test_bucket{l="c",le="1"} 0\n' +
+				'test_bucket{l="c",le="+Inf"} 0\n' +
+				'test_sum{l="a"} 1\n' +
+				'test_sum{l="b"} 5\n' +
+				'test_sum{l="c"} 0\n' +
+				'test_count{l="a"} 1\n' +
+				'test_count{l="b"} 2\n' +
+				'test_count{l="c"} 0\n'
+			);
+		});
 		it("should format Infinity and NaN", async function() {
 			let registry = new prometheus.CollectorRegistry();
 			let gauge = new prometheus.Gauge(
@@ -523,38 +757,64 @@ describe("lib/prometheus", function() {
 
 	let serializedResult = {
 		metric: { type: "type", name: "name", help: "Help", labels: ["a", "b"] },
-		samples: [['a="1",b="2"', 1], ['a="3",b="4"', 5]],
+		samples: [["", [['a="1",b="2"', 1], ['a="3",b="4"', 5]]]],
 	};
 	let deserializedResult = {
 		metric: new prometheus.Metric("type", "name", "Help", ["a", "b"]),
-		samples: new Map([['a="1",b="2"', 1], ['a="3",b="4"', 5]]),
+		samples: new Map([["", new Map([['a="1",b="2"', 1], ['a="3",b="4"', 5]])]]),
 	};
 	describe("serializeResult()", function() {
-		it("should convert a result into plain object", function() {
+		it("should convert real results into the reference serialization", async function() {
+			let counter = new prometheus.Counter("a_counter", "Counter", { register: false });
+			let gauge = new prometheus.Gauge("a_gauge", "Gauge", { register: false, labels: ["a", "b"] });
+			let registry = new prometheus.CollectorRegistry();
+			registry.register(counter);
+			registry.register(gauge);
+
+			counter.inc(3);
+			gauge.labels("1", "2").set(1);
+			gauge.labels("3", "4").set(5);
+
+			let results = [];
+			for await (let result of registry.collect()) {
+				results.push(result);
+			}
+
+			let referenceSerialization = [
+				{
+					metric: { type: "counter", name: "a_counter", help: "Counter", labels: [] },
+					samples: [["", [["", 3]]]],
+				},
+				{
+					metric: { type: "gauge", name: "a_gauge", help: "Gauge", labels: ["a", "b"] },
+					samples: [["", [['a="1",b="2"', 1], ['a="3",b="4"', 5]]]],
+				},
+			];
+
 			assert.deepEqual(
-				prometheus.serializeResult(deserializedResult),
-				serializedResult
+				results.map(result => prometheus.serializeResult(result)),
+				referenceSerialization
 			);
 		});
 		it("should support adding labels", function() {
 			assert.deepEqual(
 				prometheus.serializeResult({
 					metric: new prometheus.Metric("type", "name", "Help"),
-					samples: new Map([["", 2]]),
+					samples: new Map([["name", new Map([["", 2]])]]),
 				}, { addLabels: { c: "8" }}),
 				{
 					metric: { type: "type", name: "name", help: "Help", labels: ["c"] },
-					samples: [['c="8"', 2]],
+					samples: [["name", [['c="8"', 2]]]],
 				}
 			);
 			assert.deepEqual(
 				prometheus.serializeResult({
 					metric: new prometheus.Metric("type", "name", "Help", ["a"]),
-					samples: new Map([['a="4"', 3]]),
+					samples: new Map([["", new Map([['a="4"', 3]])]]),
 				}, { addLabels: { c: "8" }}),
 				{
 					metric: { type: "type", name: "name", help: "Help", labels: ["a", "c"] },
-					samples: [['a="4",c="8"', 3]],
+					samples: [["", [['a="4",c="8"', 3]]]],
 				}
 			);
 		});
@@ -562,21 +822,21 @@ describe("lib/prometheus", function() {
 			assert.deepEqual(
 				prometheus.serializeResult({
 					metric: new prometheus.Metric("type", "name", "Help"),
-					samples: new Map([["", 2]]),
+					samples: new Map([["", new Map([["", 2]])]]),
 				}, { metricName: "new" }),
 				{
 					metric: { type: "type", name: "new", help: "Help", labels: [] },
-					samples: [["", 2]],
+					samples: [["", [["", 2]]]],
 				}
 			);
 			assert.deepEqual(
 				prometheus.serializeResult({
 					metric: new prometheus.Metric("type", "name", "Help"),
-					samples: new Map([["", 2]]),
+					samples: new Map([["", new Map([["", 2]])]]),
 				}, { metricHelp: "old" }),
 				{
 					metric: { type: "type", name: "name", help: "old", labels: [] },
-					samples: [["", 2]],
+					samples: [["", [["", 2]]]],
 				}
 			);
 		});
@@ -584,7 +844,7 @@ describe("lib/prometheus", function() {
 			assert.throws(
 				() => prometheus.serializeResult({
 					metric: new prometheus.Metric("type", "name", "Help"),
-					samples: new Map([["", 3]]),
+					samples: new Map([["", new Map([["", 3]])]]),
 				}, { invalid: true }),
 				new Error("Unrecognized option 'invalid'")
 			);
@@ -597,6 +857,34 @@ describe("lib/prometheus", function() {
 				prometheus.deserializeResult(serializedResult),
 				deserializedResult
 			);
+		});
+	});
+
+	describe("integration", function() {
+		it("should round trip serialize histogram results", async function() {
+			let registry = new prometheus.CollectorRegistry();
+			let histogram = new prometheus.Histogram(
+				"test", "Help", { register: false, buckets: [1], labels: ["l"] }
+			);
+			for (let [value, label] of [[1, "a"], [2, "b"], [3, "b"]]) {
+				histogram.labels(label).observe(value);
+			}
+			histogram.labels("c");
+
+			registry.register(histogram);
+			let results = [];
+			for await (let result of registry.collect()) {
+				results.push(result);
+			}
+			let exposition = await prometheus.exposition(results);
+
+			let serialized = results.map(res => prometheus.serializeResult(res));
+			let jsonRoundtrip = JSON.parse(JSON.stringify(serialized));
+			let deserialized = jsonRoundtrip.map(res => prometheus.deserializeResult(res));
+			assert.deepEqual(deserialized, results);
+			let roundTripExposition = await prometheus.exposition(deserialized);
+
+			assert.equal(roundTripExposition, exposition);
 		});
 	});
 

--- a/test/mock.js
+++ b/test/mock.js
@@ -92,6 +92,10 @@ class MockInstance extends libLink.Link {
 			},
 		};
 	}
+
+	async sendRcon(command, expectEmpty, plugin) {
+		return await this.server.sendRcon(command);
+	}
 }
 
 class MockSlave extends libLink.Link {

--- a/test/slave.js
+++ b/test/slave.js
@@ -152,8 +152,7 @@ describe("Slave testing", function() {
 		it("should discover test instance", async function() {
 			let logger = { log: () => {}, error: () => {} };
 			let instancePath = path.join("test", "file", "instances");
-			let instanceInfos = new Map();
-			await slave._discoverInstances(instanceInfos, instancePath, logger);
+			let instanceInfos = await slave._discoverInstances(instancePath, logger);
 
 			let referenceConfig = new libConfig.InstanceConfig();
 			await referenceConfig.init();


### PR DESCRIPTION
Improvements to command handling and metrics that I made during my investigation of Clusterio handled large amounts of commands.  The main bottleneck that I discovered is that the number commands sent and pending a response was hard coded to 5, something which meant no more than about 150 to 200 commands could execute per second.  When the rate of command sent exceeded this they would end up getting queued and the latency between sending commands and getting a response would rise rapidly to several seconds.

Long command latencies caused metrics to stop being reported.  This was a result of the statistics_exporter plugin holding up the gathering when sending a command to retrieve statistics from the game as Prometheus by default do not wait more that 8 seconds for a response.  I fixed this in two parts by adding a timeout from the master server's request to gather metrics to slaves of 8 seconds which ensures one slave being slow will not result in metrics for the whole cluster getting lost.  The other part was adding a timeout to the statistics exporter of 5 seconds, if it takes longer the results from last time is used instead and whenever the command actually returned the metrics stored are updated.

To increase the rate of commands that can be sent to an instance I added a max_concurrent_commands option to set how many are sent in parallel.  Safe values seem to be up to 20, but 5 is a conservative default.  I also wanted to profile what was going on and decided to add an auto_start option to instances so that a profiling run could be done by setting the instances on auto start, starting up the slave with `node --prof packages/slave run`, letting it run for a while and stopping it.  This required some rework in how instance assignment is done so that slaves know which instances are actually assigned to them.  I didn't learn much from this other than the way requests are handled does not scale well when there's thousands of them pending at the same time.

The last bit of work on RCON commands was better metrics for them.  To do this I implemented the Histogram collector in lib/prometheus and decided to finally document it while at it.  That turned out a bit more work than expected, but I guess that's how it goes.  Oh and some bugs were fixed along the way.