### PR TITLE
Expose slave public_address

### DIFF
--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -288,7 +288,7 @@ messages.listSlaves = new Request({
 			type: "array",
 			items: {
 				additionalProperties: false,
-				required: ["agent", "version", "name", "id", "connected", "public_address"],
+				required: ["agent", "version", "name", "id", "connected"],
 				properties: {
 					"agent": { type: "string" },
 					"version": { type: "string" },

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -288,13 +288,14 @@ messages.listSlaves = new Request({
 			type: "array",
 			items: {
 				additionalProperties: false,
-				required: ["agent", "version", "name", "id", "connected"],
+				required: ["agent", "version", "name", "id", "connected", "public_address"],
 				properties: {
 					"agent": { type: "string" },
 					"version": { type: "string" },
 					"name": { type: "string" },
 					"id": { type: "integer" },
 					"connected": { type: "boolean" },
+					"public_address": { type: "string" },
 				},
 			},
 		},

--- a/packages/master/master.js
+++ b/packages/master/master.js
@@ -656,6 +656,7 @@ class ControlConnection extends BaseConnection {
 				id: slave.id,
 				name: slave.name,
 				connected: slaveConnections.has(slave.id),
+				public_address: slave.public_address,
 			});
 		}
 		return { list };

--- a/packages/web_ui/src/components/SlavesPage.jsx
+++ b/packages/web_ui/src/components/SlavesPage.jsx
@@ -18,6 +18,7 @@ export default function SlavesPage() {
 			"Agent": item["agent"],
 			"Version": item["version"],
 			"Connected": item["connected"] && "Yes",
+			"Address": item["public_address"],
 		}));
 	}
 

--- a/test/lib/command.js
+++ b/test/lib/command.js
@@ -16,7 +16,7 @@ describe("lib/command", function() {
 				seq: 1, type: "list_slaves_response",
 				data: {
 					seq: message.seq,
-					list: [{ agent: "test", version: "0.1", id: 11, name: "Test Slave", connected: false }],
+					list: [{ agent: "test", version: "0.1", id: 11, name: "Test Slave", connected: false, public_address: "example.com" }],
 				},
 			});
 		} else if (message.type === "list_instances_request") {


### PR DESCRIPTION
Exposes the public_address field from the slave config in messages.listSlaves and in the table in the web interface as requested by L1n3 on discord. The field was made optional as exposing the slave to a public address shouldn't be mandatory IMO.

I think I caught all the places that need updating for this, not entirely sure though.