### PR TITLE
Improve config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,14 @@ Configuration
 Master Configuration
 --------------------
 
+### master.name
+
+Name of the cluster.  Used to distinguish it from other clusters and is
+prepended to the name of servers in the server list.
+
+Defaluts to "Your Cluster".
+
+
 ### master.database_directory
 
 Directory used to store cluster data to.  Needs to be writeable by the

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -381,8 +381,10 @@ the event, for example the following could be defined in `info.js`:
             type: "foo_frobber:start_frobnication",
             links: ["master-slave", "slave-instance"],
             forwardTo: "instance",
+            eventRequired: ["frobnication_type"],
             eventProperties: {
                 "frobnication_type": { type: "string" },
+                "urgent": { type: "boolean" },
             },
         }),
     },
@@ -390,8 +392,8 @@ the event, for example the following could be defined in `info.js`:
 This specifies an event that can be sent from the master to a slave,
 and from a slave to an instance.  It also specifies that the event must
 contain the property `frobnication_type`, with a string value in the
-data payload.  It will also be forwarded by slaves to a specific
-instance.
+data payload and that it may optionally contain a boolean `urgent`
+property.  It will also be forwarded by slaves to a specific instance.
 
 The following properties are recognized by the Event constructor:
 
@@ -434,12 +436,19 @@ it's sent to, but not back from where it came from. Currently, only
 that slave except for the instance it came from.  from an instance will
 cause it to be broadcast to all instances of
 
+#### eventRequired
+
+By default all properties defined in `eventProperties` are required to
+be present in the payload for the event.  This can be overriden by
+specifying an array of properties which are required here.  This is
+equivalent to using the `required` keyword in JSON schema.
+
 #### eventProperties
 
 Object with properties mapping to a JSON schema of that property that
 specifies what's valid to send in the event.  This is equivalent to
 using the `properties` keyword in JSON schema, except that the
-properties specified are implicitly required and additional properties
+properties specified are by default required and additional properties
 are not allowed.  See [this guide][guide] for an introduction to writing
 JSON schemas.
 
@@ -466,8 +475,10 @@ the event. For example, the following could be defined in `info.js`:
             type: "foo_frobber:report_frobnication",
             links: ["master-slave", "slave-instance"],
             forwardTo: "instance",
+            requestRequired: ["verbosity"],
             requestProperties: {
                 "verbosity": { type: "integer" },
+                "special": { type: "boolean" },
             },
             responseProperties: {
                 "report": {
@@ -481,7 +492,8 @@ the event. For example, the following could be defined in `info.js`:
 This specifies a request that can be sent from the master to a slave,
 and from a slave to an instance.  The request data must contain the
 property `verbosity` with an integer number as the value, as well as the
-`instance_id` property (implied by `forwardTo: "instance"`), and the
+`instance_id` property (implied by `forwardTo: "instance"`) and it may
+also contain a boolean `special` property.  It also defines that the
 response sent must contain a `report` property mapping to an array of
 strings.  When received by a slave, it will also be forwarded to the
 instance specified by `instance_id`.
@@ -520,14 +532,26 @@ instance, or `"instance"` to indicate it should be forwarded to the
 instances specified by the `instance_id` request property.  This works
 by using a default handler for the request by the links that forward it.
 
+#### requestRequired
+
+By default all properties defined in `requestProperties` are required to
+be present in the payload for the request.  This can be overriden by
+specifying an array of properties which are required here.  This is
+equivalent to using the `required` keyword in JSON schema.
+
 #### requestProperties
 
 Object with properties mapping to a JSON schema of that property that
 specifies what's valid to send in the request.  This is equivalent to
 using the `properties` keyword in JSON schema, except that the
-properties specified are implicitly required and additional properties
+properties specified are by default required and additional properties
 are not allowed.  See [this guide][guide] for an introduction to writing
 JSON schemas
+
+#### responseRequired
+
+Same as the requestRequired only for the response sent back by the
+target.
 
 #### responseProperties
 

--- a/packages/lib/config/classes.js
+++ b/packages/lib/config/classes.js
@@ -448,7 +448,11 @@ class ConfigGroup {
 		let prev = this._fields.get(name);
 		let updated = {...prev || {}};
 
-		updated[prop] = value;
+		if (value !== undefined) {
+			updated[prop] = value;
+		} else {
+			delete updated[prop];
+		}
 		this._fields.set(name, updated);
 		if (this._config && !isDeepStrictEqual(updated, prev)) {
 			this._config.emit("fieldChanged", this, name, prev);

--- a/packages/lib/config/definitions.js
+++ b/packages/lib/config/definitions.js
@@ -12,6 +12,13 @@ const classes = require("./classes");
 class MasterGroup extends classes.ConfigGroup { }
 MasterGroup.groupName = "master";
 MasterGroup.define({
+	name: "name",
+	title: "Name",
+	description: "Name of the cluster",
+	type: "string",
+	initial_value: "Your Cluster",
+});
+MasterGroup.define({
 	name: "database_directory",
 	title: "Database directory",
 	description: "Directory where item and configuration data is stored.",
@@ -262,10 +269,7 @@ FactorioGroup.define({
 	name: "settings",
 	description: "Settings overridden in server-settings.json",
 	type: "object",
-	initial_value: {
-		"tags": ["clusterio"],
-		"auto_pause": false,
-	},
+	initial_value: {}, // See create instance handler in master.
 });
 FactorioGroup.define({
 	name: "verbose_logging",

--- a/packages/lib/helpers.js
+++ b/packages/lib/helpers.js
@@ -52,8 +52,32 @@ async function timeout(promise, time, timeoutResult) {
 	}
 }
 
+
+/**
+ * Read stream to the end and return its content
+ *
+ * Reads the stream given asynchronously until the end is reached and
+ * returns all the data which was read from the stream.
+ *
+ * @param {Readable} stream - byte stream to read to the end.
+ * @returns {Buffer} content of the stream.
+ */
+async function readStream(stream) {
+	let chunks = [];
+	for await (let chunk of stream) {
+		// Support using ^Z to end input on Windows
+		if (process.platform === "win32" && stream.isTTY && chunk.toString() === "\x1a\r\n") {
+			break;
+		}
+		chunks.push(chunk);
+	}
+	return Buffer.concat(chunks);
+}
+
+
 module.exports = {
 	basicType,
 	wait,
 	timeout,
+	readStream,
 };

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -70,16 +70,24 @@ class Request extends Message {
 	 *     Optional target to forward this request to.  'instance' add
 	 *     instance_id into the requestProperties and forward to the given
 	 *     instance.  'master' forwards it to the master server.
+	 * @param {?Array<string>} requestRequired -
+	 *     List of properties that are required to be present in the data
+	 *     payload of this request.  Defaults to all.
 	 * @param {Object<string, Object>} requestProperties -
 	 *     Mapping of property values to JSON schema specifications for the
 	 *     properties that are valid in the data payload of this requst.
+	 * @param {?Array<string>} responseRequired -
+	 *     List of properties that are required to be present in the data
+	 *     payload of the repsonse to this request.  Defaults to all.
 	 * @param {Object<string, Object>} responseProperties -
 	 *     Mapping of property values to JSON schema specifications for the
 	 *     properties that are valid in the data payload of the response to
 	 *     this requst.
 	 */
 	constructor({
-		type, permission, links, forwardTo = null, requestProperties = {}, responseProperties = {},
+		type, permission, links, forwardTo = null,
+		requestRequired = null, requestProperties = {},
+		responseRequired = null, responseProperties = {},
 	}) {
 		super();
 		this.type = type;
@@ -98,7 +106,12 @@ class Request extends Message {
 			throw new Error(`permission is not allowed on ${this.type} request as it is not over control-master link`);
 		}
 
+		if (!requestRequired) {
+			requestRequired = Object.keys(requestProperties);
+		}
+
 		if (forwardTo === "instance") {
+			requestRequired = ["instance_id", ...requestRequired];
 			requestProperties = {
 				"instance_id": { type: "integer" },
 				...requestProperties,
@@ -114,11 +127,15 @@ class Request extends Message {
 				"type": { const: this.requestType },
 				"data": {
 					additionalProperties: false,
-					required: Object.keys(requestProperties),
+					required: requestRequired,
 					properties: requestProperties,
 				},
 			},
 		});
+
+		if (!responseRequired) {
+			responseRequired = Object.keys(responseProperties);
+		}
 
 		this._responseValidator = libSchema.compile({
 			$schema: "http://json-schema.org/draft-07/schema#",
@@ -128,7 +145,7 @@ class Request extends Message {
 					anyOf: [
 						{
 							additionalProperties: false,
-							required: ["seq", ...Object.keys(responseProperties)],
+							required: ["seq", ...responseRequired],
 							properties: {
 								"seq": { type: "integer" },
 								...responseProperties,
@@ -760,11 +777,14 @@ class Event extends Message {
 	 *     links that are downstream, so sending an event set to instance
 	 *     broadcast that's sent to a slave will only be broadcast to that
 	 *     slave's instances.
+	 * @param {?Array<string>} eventRequired -
+	 *     List of properties required to be present in the event payload.
+	 *     Defaults to all.
 	 * @param {Object<string, Object>} eventProperties -
 	 *     Mapping of property values to JSON schema specifications for the
 	 *     properties that are valid in the data payload of this event.
 	 */
-	constructor({ type, links, forwardTo = null, broadcastTo = null, eventProperties = {} }) {
+	constructor({ type, links, forwardTo = null, broadcastTo = null, eventRequired = null, eventProperties = {} }) {
 		super();
 		this.type = type;
 		this.links = links;
@@ -772,7 +792,12 @@ class Event extends Message {
 		this.broadcastTo = broadcastTo;
 		this.handlerSuffix = "EventHandler";
 
+		if (!eventRequired) {
+			eventRequired = Object.keys(eventProperties);
+		}
+
 		if (forwardTo === "instance") {
+			eventRequired = ["instance_id", ...eventRequired];
 			eventProperties = {
 				"instance_id": { type: "integer" },
 				...eventProperties,
@@ -793,7 +818,7 @@ class Event extends Message {
 				"type": { const: this.eventType },
 				"data": {
 					additionalProperties: false,
-					required: Object.keys(eventProperties),
+					required: eventRequired,
 					properties: eventProperties,
 				},
 			},

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -407,6 +407,7 @@ messages.setInstanceConfigProp = new Request({
 	type: "set_instance_config_prop",
 	links: ["control-master"],
 	permission: "core.instance.update_config",
+	requestRequired: ["instance_id", "field", "prop"],
 	requestProperties: {
 		"instance_id": { type: "integer" },
 		"field": { type: "string" },

--- a/packages/lib/shared_commands.js
+++ b/packages/lib/shared_commands.js
@@ -8,6 +8,7 @@ const path = require("path");
 
 const libConfig = require("@clusterio/lib/config");
 const { logger } = require("@clusterio/lib/logging");
+const libHelpers = require("@clusterio/lib/helpers");
 
 
 function print(...content) {
@@ -100,7 +101,11 @@ async function handlePluginCommand(args, pluginList, pluginListPath) {
  */
 function configCommand(yargs) {
 	yargs
-		.command("set <field> [value]", "Set config field")
+		.command("set <field> [value]", "Set config field", yargs => {
+			yargs.options({
+				"stdin": { describe: "read value from stdin", nargs: 0, type: "boolean" },
+			});
+		})
 		.command("show <field>", "Show value of the given config field")
 		.command("list", "List all configuration fields and their values")
 		.demandCommand(1, "You need to specify a command to run")
@@ -141,7 +146,10 @@ async function handleConfigCommand(args, instance, configPath) {
 		}
 
 	} else if (command === "set") {
-		if (args.value === undefined) {
+		if (args.stdin) {
+			args.value = (await libHelpers.readStream(process.stdin)).toString().replace(/\r?\n$/, "");
+
+		} else if (args.value === undefined) {
 			args.value = null;
 		}
 

--- a/packages/master/master.js
+++ b/packages/master/master.js
@@ -741,6 +741,33 @@ class ControlConnection extends BaseConnection {
 		if (db.instances.has(instanceId)) {
 			throw new libErrors.RequestError(`Instance with ID ${instanceId} already exists`);
 		}
+
+		// Add common settings for the Factorio server
+		let settings = {
+			"name": `${masterConfig.get("master.name")} - ${instanceConfig.get("instance.name")}`,
+			"description": `Clusterio instance for ${masterConfig.get("master.name")}`,
+			"tags": ["clusterio"],
+			"max_players": 0,
+			"visibility": { "public": true, "lan": true },
+			"username": "",
+			"token": "",
+			"game_password": "",
+			"require_user_verification": true,
+			"max_upload_in_kilobytes_per_second": 0,
+			"max_upload_slots": 5,
+			"ignore_player_limit_for_returning_players": false,
+			"allow_commands": "admins-only",
+			"autosave_interval": 10,
+			"autosave_slots": 5,
+			"afk_autokick_interval": 0,
+			"auto_pause": false,
+			"only_admins_can_pause_the_game": true,
+			"autosave_only_on_server": true,
+
+			...instanceConfig.get("factorio.settings"),
+		};
+		instanceConfig.set("factorio.settings", settings);
+
 		db.instances.set(instanceId, { config: instanceConfig, status: "unassigned" });
 	}
 

--- a/test/lib/config/classes.js
+++ b/test/lib/config/classes.js
@@ -397,6 +397,12 @@ describe("lib/config/classes", function() {
 				testInstance.setProp("json", "test", true);
 				assert.deepEqual(testInstance.get("json"), { test: true });
 			});
+
+			it("should unset field if passed undefined", function() {
+				testInstance.set("json", { test: true, extra: "yes" });
+				testInstance.setProp("json", "extra", undefined);
+				assert.deepEqual(testInstance.get("json"), { test: true });
+			});
 		});
 	});
 

--- a/test/lib/link/messages.js
+++ b/test/lib/link/messages.js
@@ -17,11 +17,15 @@ describe("lib/link/messages", function() {
 		let testRequest = new libLink.Request({
 			type: "test",
 			links: ["source-target"],
+			requestRequired: ["test"],
 			requestProperties: {
 				"test": { type: "string" },
+				"optional": { type: "number" },
 			},
+			responseRequired: ["test"],
 			responseProperties: {
 				"test": { type: "string" },
+				"optional": { type: "number" },
 			},
 		});
 
@@ -127,8 +131,10 @@ describe("lib/link/messages", function() {
 		let testEvent = new libLink.Event({
 			type: "test",
 			links: ["source-target"],
+			eventRequired: ["test"],
 			eventProperties: {
 				"test": { type: "string" },
+				"optional": { type: "number" },
 			},
 		});
 


### PR DESCRIPTION
Improvements targeting the config user experience:
- Assumes bad JSON passed to set-prop is supposed to be a string, which is a correct assumption most of the time and avoids having to deal with the layers of quoting and escaping.
- Adds `--stdin` option to set config entries from the command line as another means to avoid having to deal with quoting and escaping.
- Adds ability to remove properties in object fields with set-prop
- Adds interface to add and remove properties to object fields in the web interface.
- Adds the common properties from server-settings.json to factorio.settings so it's easier to discover and manage them.