### PR TITLE
Fix crash on continuing an active connection

### DIFF
--- a/packages/lib/link/connectors.js
+++ b/packages/lib/link/connectors.js
@@ -75,6 +75,9 @@ class WebSocketBaseConnector extends events.EventEmitter {
 	 * Start sending heartbeats
 	 */
 	startHeartbeat() {
+		if(this._heartbeatId) {
+			throw new Error("heartbeat is already running");
+		}
 		this._lastHeartbeat = Date.now();
 		this._heartbeatId = setInterval(() => {
 			this._doHeartbeat();

--- a/packages/lib/link/connectors.js
+++ b/packages/lib/link/connectors.js
@@ -75,7 +75,7 @@ class WebSocketBaseConnector extends events.EventEmitter {
 	 * Start sending heartbeats
 	 */
 	startHeartbeat() {
-		if(this._heartbeatId) {
+		if (this._heartbeatId) {
 			throw new Error("heartbeat is already running");
 		}
 		this._lastHeartbeat = Date.now();

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -197,6 +197,7 @@ module.exports = {
 	getControl,
 
 	url,
+	controlToken,
 	instancesDir,
 	databaseDir,
 	masterConfigPath,


### PR DESCRIPTION
Fix ServerConnector reaching an invalid state if a continue operation is
performed on an active connection.  The continue would cause the
connection established logic to be runned before the connection lost
logic of the pervious connection is perfomed, resulting in a leaked
heartbeat interval and the connection lost logic being performed on the
new connection instead of the old.  Prevent this by closing both the new
and the old connection in this case.