### PR TITLE
Use a diff and author friendly markdown formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,64 +1,48 @@
-Changelog
-=========
+# Changelog
 
-Version 2.0.0
--------------
+## Version 2.0.0
 
 ### Major Features
 
-- Replaced Hotpatch with save patching.  Removed the Hotpatch scenario and
-  the depency on it for getting code into the game.  Added a save patcher than
-  runs before starting up Factorio that patches in lua modules based on the
-  event_loader lib into the savegame.  Regular freeplay games can now be
-  used with Clusterio and will be compatible without having to convert them
-  to Hotpatch.
-- Daemonized slaves.  Slaves now have the ability to run multiple Factorio
-  instances, starting and stopping them individually.  To manage this the
-  local command line interface has been replaced with a remote interface on
-  the master server that can be accessed through the clusterioctl cli tool.
-- Rewritten the communication between slaves and the master from scratch.  The
-  new system is based on a WebSocket connection between the slaves and the
-  master server and provides efficient validated bi-directonal communication.
-- Rewritten the plugin system from scratch.  Plugins now inherit from
-  a base class and use the same WebSocket connection Clusterio uses to
-  communicate.
-- New configuration system with support for initializing configs when needed,
-  modifying config entries using built-in commands, and updating instance
-  configuration remotely.
-- Packaged and uploaded to npm again, greatly simplifying distribution and
-  installation of both Clusterio and plugins.
-- Added centralized logging for the cluster.  All logs from both Clusterio
-  and Factorio is stored in a shared log which can be inspected and queried.
+- Replaced Hotpatch with save patching.
+  Removed the Hotpatch scenario and the depency on it for getting code into the game.
+  Added a save patcher than runs before starting up Factorio that patches in lua modules based on the event_loader lib into the savegame.
+  Regular freeplay games can now be used with Clusterio and will be compatible without having to convert them to Hotpatch.
+- Daemonized slaves.
+  Slaves now have the ability to run multiple Factorio instances, starting and stopping them individually.
+  To manage this the local command line interface has been replaced with a remote interface on the master server that can be accessed through the clusterioctl cli tool.
+- Rewritten the communication between slaves and the master from scratch.
+  The new system is based on a WebSocket connection between the slaves and the master server and provides efficient validated bi-directonal communication.
+- Rewritten the plugin system from scratch.
+  Plugins now inherit from a base class and use the same WebSocket connection Clusterio uses to communicate.
+- New configuration system with support for initializing configs when needed, modifying config entries using built-in commands, and updating instance configuration remotely.
+- Packaged and uploaded to npm again, greatly simplifying distribution and installation of both Clusterio and plugins.
+- Added centralized logging for the cluster.
+  All logs from both Clusterio and Factorio is stored in a shared log which can be inspected and queried.
 
 ### Features
 
 - Added export of pollution statitics.
-- Reconnection logic that esures no data is dropped talking to the master
-  server provided the session can be resumed.
-- Added support for having multiple Factorio installs and selecting which
-  version to use on a per instance basis.
-- Added config to specify which path the master interface is accessed under,
-  allowing it to be proxied behind web-server.
+- Reconnection logic that esures no data is dropped talking to the master server provided the session can be resumed.
+- Added support for having multiple Factorio installs and selecting which version to use on a per instance basis.
+- Added config to specify which path the master interface is accessed under, allowing it to be proxied behind web-server.
 - Added WebSocket usage statistics.
 - Added commands sent statistic.
 - Added Factorio server CPU and memory usage statistic.
 - Added Factorio autosave size statistic.
 - Added support for extracting locale and item icons from Factorio and mods.
-- Added integrated user management for controlling access and storing per
-  player data.
-- Added synchronization of in-game adminlist, banlist and whitelist to
-  Clusterio core.  Previously this was handled by the playerManager plugin.
+- Added integrated user management for controlling access and storing per player data.
+- Added synchronization of in-game adminlist, banlist and whitelist to Clusterio core.
+  Previously this was handled by the playerManager plugin.
 - Added stripping of long paths in the Factorio server log.
 - Added option to configure maximum number of commands to send in parallel.
 - Added option to auto start instances on slave startup.
-- Added metric mapping of slave and instance ids to their names, allowing
-  them to be displayed by name in queries that join with the mapping.
+- Added metric mapping of slave and instance ids to their names, allowing them to be displayed by name in queries that join with the mapping.
 - Added option to configure timeout for exported Prometheus metrics.
 - Added option to set address to bind HTTP(S) port to.
 - Added an overview of the installed plugins to the web interface.
 - Added clusterioctl command to list plugins on the master server.
-- Added Player Auth plugin for logging in to the web interface by proving
-  the ability to log in to a server as a given user.
+- Added Player Auth plugin for logging in to the web interface by proving the ability to log in to a server as a given user.
 
 ### Changes
 
@@ -66,186 +50,137 @@ Version 2.0.0
 - Factorio game and rcon port now defaults to a random port above 49151.
 - Removed unimplemented mods update command.
 - Fixed rcon password being generated with Math.random().
-- Added plugins directory to the views path.  This makes it possible for
-  plugins to render their own ejs views or pages in their own folders by
-  using paths of the format "pluginName/path/to/page-or-view".
-- Replaced the per instance copy of the shared Factorio mods with
-  symlinks.  On Windows hard links are used instead due to the
-  privileges requirements of symlinks.
-- Changed the per instance scenario folder to be linked instead of
-  copied on instance creation.
-- Instance id is no longer derived from the rcon password, instead it's
-  generated upon instance creation and stored in the instance config.
-- The game port, RCON port and RCON password instance config entries are are
-  now null by default, indicating that a random one will be generated every
-  time the instance is started.
-- Removed the broken client download command as this would download
-  pre-releases.
-- Moved the item database and HTTP definitions for /api/place, /api/remove,
-  /api/inventory, /api/inventoryAsObject and the web interface view for the
-  storage page into the clusterioMod plugin.  If you disable this plugin
-  then these things will not be available.
+- Added plugins directory to the views path.
+  This makes it possible for plugins to render their own ejs views or pages in their own folders by using paths of the format "pluginName/path/to/page-or-view".
+- Replaced the per instance copy of the shared Factorio mods with symlinks.
+  On Windows hard links are used instead due to the privileges requirements of symlinks.
+- Changed the per instance scenario folder to be linked instead of copied on instance creation.
+- Instance id is no longer derived from the rcon password, instead it's generated upon instance creation and stored in the instance config.
+- The game port, RCON port and RCON password instance config entries are are now null by default, indicating that a random one will be generated every time the instance is started.
+- Removed the broken client download command as this would download pre-releases.
+- Moved the item database and HTTP definitions for /api/place, /api/remove, /api/inventory, /api/inventoryAsObject and the web interface view for the storage page into the clusterioMod plugin.
+  If you disable this plugin then these things will not be available.
 - Removed undocumented --port and --rcon-port arguments to client.
-- Removed undocumented FACTORIOPORT and RCONPORT enviroment variable
-  handling in client.
+- Removed undocumented FACTORIOPORT and RCONPORT enviroment variable handling in client.
 - Removed redundant call to /api/slaves in globalChat plugin.
 - Removed broken serverManager plugin.
-- Removed factorio_version from config.  The version installed is auto
-  detected and used instead.
+- Removed factorio_version from config.
+  The version installed is auto detected and used instead.
 - Removed the playerManager specific command CLI tools/delete_player.js.
-- Creating an instance, assigning it to a slave, creating a save for an
-  instance and starting an instance is now four separate commands.
+- Creating an instance, assigning it to a slave, creating a save for an instance and starting an instance is now four separate commands.
 - Removed oddball limits to slaves.json size.
-- Moved slave specific and instance specific configuration into their own
-  configuration files.
+- Moved slave specific and instance specific configuration into their own configuration files.
 - Removed unused binary option from plugin config.
-- Removed info and shout command from globalChat plugin
-- Removed mirrorAllChat and enableCrossServerShout configuration options for
-  globalChat plugin.
-- Removed UPSdisplay plugin.  UPS statistics is exported by the statistics
-  exporter plugin.
+- Removed info and shout command from globalChat plugin - Removed mirrorAllChat and enableCrossServerShout configuration options for globalChat plugin.
+- Removed UPSdisplay plugin.
+  UPS statistics is exported by the statistics exporter plugin.
 - Master server now defaults to hosting on https on port 8443.
 - Renamed client to slave.
 
 ### Breaking Changes
 
-- Removed lib/authenticate.  Breaks playerManager.
+- Removed lib/authenticate.
+  Breaks playerManager.
 - The masterIP and masterPort config entries has been merged into masterURL.
-  Breaks discordChat, playerManager, serverSelect, trainTeleports and
-  clusterioModel.
+  Breaks discordChat, playerManager, serverSelect, trainTeleports and clusterioModel.
 - Instance names can no longer be invalid Windows file names.
 - Removed config management from the command line and the server manager.
-- Moved ejs templates into views folder and changed their extension to
-  .ejs.  Breaks playerManager.
+- Moved ejs templates into views folder and changed their extension to .ejs.
+  Breaks playerManager.
 - Mods are no longer copied from the per instance instanceMods directory.
-  If you need per instance mods you can now place them directly in the mods
-  directory inside the instance folder.
+  If you need per instance mods you can now place them directly in the mods directory inside the instance folder.
 - Hotpatch scenarios and code loading is no longer compatible with Clusterio.
   Breaks playerManager, serverSelect, and tranTeleports.
-- Removed getLua and getCommand from lib/clusterTools.  If you need to run
-  more than the most trivial of code in commands use the save patcher and
-  add in a remote interface.
-- Removed mod uploading and distributing from the HTTP interface.  Breaks
-  the old unmaintained and no longer needed factorioClusterioClient.
-- Removed the remoteCommands plugin and the old runCommand interface.  Breaks
-  playerManager and external tools sending commands.
+- Removed getLua and getCommand from lib/clusterTools.
+  If you need to run more than the most trivial of code in commands use the save patcher and add in a remote interface.
+- Removed mod uploading and distributing from the HTTP interface.
+  Breaks the old unmaintained and no longer needed factorioClusterioClient.
+- Removed the remoteCommands plugin and the old runCommand interface.
+  Breaks playerManager and external tools sending commands.
 - Removed broken serverManager plugin.
-- Removed fields info, time, rconPort, rconPassword, serverPort, unique,
-  mods, instanceName, playerCount, mac, and meta from the slaves in the
-  slave database.
-- Removed getInstanceName and lib/clusterTools.  Breaks playerManager,
-  and discordChat.
-- Removed the /api/rconPasswords, and /api/slaves endpoints.  Breaks web
-  interface, trainTeleports, and discordChat.
-- Removed the /api/getSlaveMeta and /api/editSlaveMeta endpoints.  Breaks
-  researchSync, and UPSdisplay.
-- Removed the hello event from the socket connection handshake.  Breaks
-  playerManager, trainTeleports, serverSelect, and discordChat
+- Removed fields info, time, rconPort, rconPassword, serverPort, unique, mods, instanceName, playerCount, mac, and meta from the slaves in the slave database.
+- Removed getInstanceName and lib/clusterTools.
+  Breaks playerManager, and discordChat.
+- Removed the /api/rconPasswords, and /api/slaves endpoints.
+  Breaks web interface, trainTeleports, and discordChat.
+- Removed the /api/getSlaveMeta and /api/editSlaveMeta endpoints.
+  Breaks researchSync, and UPSdisplay.
+- Removed the hello event from the socket connection handshake.
+  Breaks playerManager, trainTeleports, serverSelect, and discordChat
 - Changed the format of database/slaves.json.
-- Removed the output file subscription system.  Breaks inventoryImports,
-  playerManager, trainTeleports, serverSelect and researchSync.
-- Removed the factorioOutput hook from instance plugins.  The onOutput
-  hook provides parsed output instead.
+- Removed the output file subscription system.
+  Breaks inventoryImports, playerManager, trainTeleports, serverSelect and researchSync.
+- Removed the factorioOutput hook from instance plugins.
+  The onOutput hook provides parsed output instead.
 - Removed the onLoadFinish hook from master plugins.
 - Moved plugins from the sharedPlugins directory to plugins directory.
-- Implemented a new plugin system that replaces the old.  Breaks all plugins.
+- Implemented a new plugin system that replaces the old.
+  Breaks all plugins.
 - Removed express metric http_request_duration_milliseconds metric.
-- Removed socket.io metrics socket_io_connected, socket_io_connect_total,
-  socket_io_disconnect_total, socket_io_events_received_total,
-  socket_io_events_sent_total, socket_io_recieve_bytes, and
-  socket_io_transmit_bytes,
-- Removed clusterio_connected_instaces_gauge and added
-  clusterio_master_connected_clients_count in its place.
-- Renamed clusterio_player_count_gauge to
-  clusterio_statistics_exporter_instance_player_count
-- Removed clusterio_UPS_gauge and added
-  clusterio_statistics_exporter_instance_game_ticks_total in its place.
+- Removed socket.io metrics socket_io_connected, socket_io_connect_total, socket_io_disconnect_total, socket_io_events_received_total, socket_io_events_sent_total, socket_io_recieve_bytes, and socket_io_transmit_bytes,
+- Removed clusterio_connected_instaces_gauge and added clusterio_master_connected_clients_count in its place.
+- Renamed clusterio_player_count_gauge to clusterio_statistics_exporter_instance_player_count
+- Removed clusterio_UPS_gauge and added clusterio_statistics_exporter_instance_game_ticks_total in its place.
 - Renamed clusterio_endpoint_hit_gauge to clusterio_http_enpoint_hits_total
-- Renamed clusterio_statistics_gauge to
-  clusterio_statistics_exporter_instance_force_flows
+- Renamed clusterio_statistics_gauge to clusterio_statistics_exporter_instance_force_flows
 - Renamed clusterio_nn_dole_gauge to clusterio_subspace_storage_nn_dole_gauge.
-- Renamed clusterio_dole_factor_gauge to
-  clusterio_subspace_storage_dole_factor_gauge.
+- Renamed clusterio_dole_factor_gauge to clusterio_subspace_storage_dole_factor_gauge.
 - Renamed clusterio_import_gauge to clusterio_subspace_storage_import_total.
 - Renamed clusterio_export_gauge to clusterio_subspace_storage_export_total.
-- Renamed clusterio_master_inventory_gauge to
-  clusterio_subspace_storage_master_inventory.
-- Removed clusterioMod plugin specific config options logItemTransfers,
-  disableFairItemDistribution useNeuralNetDoleDivider, autosaveInterval, and
-  disableImportsOfEverythingExceptElectricity from the master config.
-- Removed msBetweenCommands config option.  The RCON is instead limited to 5
-  concurrent commands.
-- Removed allowRemoteCommandExecution config option.  Remote commands are
-  always allowed with the move to master managing slaves/instances.
-- Removed `--databaseDirectory`, `--masterPort`, and `--sslPort` command line
-  arguments from the master server.
-- Implemented a new config system that replaces the old.  Breaks all plugins.
+- Renamed clusterio_master_inventory_gauge to clusterio_subspace_storage_master_inventory.
+- Removed clusterioMod plugin specific config options logItemTransfers, disableFairItemDistribution useNeuralNetDoleDivider, autosaveInterval, and disableImportsOfEverythingExceptElectricity from the master config.
+- Removed msBetweenCommands config option.
+  The RCON is instead limited to 5 concurrent commands.
+- Removed allowRemoteCommandExecution config option.
+  Remote commands are always allowed with the move to master managing slaves/instances.
+- Removed `--databaseDirectory`, `--masterPort`, and `--sslPort` command line arguments from the master server.
+- Implemented a new config system that replaces the old.
+  Breaks all plugins.
 - Removed usage of socket.io entirely in favor of a plain WebSocket connection.
 - Renamed clusterioMod plugin to subspace_storage.
 - Master no longer creates secret-api-token.txt.
 - Removed automatic creation of self-signed TLS certificate.
 
 
-Version 1.2.4
--------------
+## Version 1.2.4
 
 - Removed broken remote combinator signaling.
 - Fixed research sync endlessly updating already researched technologies
 - Removed obsolete item/fluid statistics from clusterioMod
 - Removed per mod upload logging when config.uploadModsToMaster disabled
-- Fixed bcrypt failing to install on windows due to the new version not
-  having Windows binaries.
+- Fixed bcrypt failing to install on windows due to the new version not having Windows binaries.
 
 
-Version 1.2.3
--------------
+## Version 1.2.3
 
-- Disabled uploading mods to the master server by default as this is mostly
-  just a waste of bandwidth with the mod portal being integrated into the
-  game now.
-- Fixed researchSync breaking with heavily modded games due to the tech tree
-  exceeding the default 100kb limit on JSON payloads.
-- Fixed the command inventoryImport sends referencing player instead of
-  character, and trying to count the non-existant quick bar slots.
-- Fixed inventoryImport never receiving the script output after the default
-  mode for reading script output changed to tail mode.
-- Fixed desync caused by the mods and loaded mods arrays in Hotpatch getting
-  out of sync when plugins update their scenario mod code.  To fix existing
-  games you will need copy lib/scenarios/Hotpatch/hotpatch/mod-tools.lua
-  over the existing mod-tools.lua in the save's hotpatch folder.
+- Disabled uploading mods to the master server by default as this is mostly just a waste of bandwidth with the mod portal being integrated into the game now.
+- Fixed researchSync breaking with heavily modded games due to the tech tree exceeding the default 100kb limit on JSON payloads.
+- Fixed the command inventoryImport sends referencing player instead of character, and trying to count the non-existant quick bar slots.
+- Fixed inventoryImport never receiving the script output after the default mode for reading script output changed to tail mode.
+- Fixed desync caused by the mods and loaded mods arrays in Hotpatch getting out of sync when plugins update their scenario mod code.
+  To fix existing games you will need copy lib/scenarios/Hotpatch/hotpatch/mod-tools.lua over the existing mod-tools.lua in the save's hotpatch folder.
 - Updated the Windows install instructions.
 
 
-Version 1.2.2
--------------
+## Version 1.2.2
 
-- Fixed possible crash with modded technologies named the same as a built-in
-  Object prototype property in researchSync.
-- Fixed progress of a current infinite tech carrying over to the next one
-  when researching it and another node completes it in researchSync.
-- Fixed progress of a previous infinite tech from another node being applied
-  to the current one in researchSync.
-- Fixed crash in researchSync when modded technologies are present only on some
-  nodes.
-- Fixed install failing due to bcrypt version less than 3 not being supported
-  on node v10.
-- Reordered install instructions to avoid problem with npm creating files owned
-  by root in the home directory.
-- Swapped curl out with wget in the install instructions as the latter comes
-  pre-installed on Ubuntu.
+- Fixed possible crash with modded technologies named the same as a built-in Object prototype property in researchSync.
+- Fixed progress of a current infinite tech carrying over to the next one when researching it and another node completes it in researchSync.
+- Fixed progress of a previous infinite tech from another node being applied to the current one in researchSync.
+- Fixed crash in researchSync when modded technologies are present only on some nodes.
+- Fixed install failing due to bcrypt version less than 3 not being supported on node v10.
+- Reordered install instructions to avoid problem with npm creating files owned by root in the home directory.
+- Swapped curl out with wget in the install instructions as the latter comes pre-installed on Ubuntu.
 
 ### Breaking Changes
 
 - Node.js versions below 10 are no longer supported.
 
 
-Version 1.2.1
--------------
+## Version 1.2.1
 
-- Updated node-factorio-api to v0.3.8 to fix mod downloads randomly breaking
-  ([#229][#229].)
-- Fixed SIGINT being sent twice to Factorio server when interrupted by CTRL+C
-  on Linux ([#217][#217].)
+- Updated node-factorio-api to v0.3.8 to fix mod downloads randomly breaking ([#229][#229]).
+- Fixed SIGINT being sent twice to Factorio server when interrupted by CTRL+C on Linux ([#217][#217]).
 - Fixed package.json incorrectly reporting the license as ISC.
 
 [#217]: https://github.com/clusterio/factorioClusterio/issues/217

--- a/README.md
+++ b/README.md
@@ -10,21 +10,20 @@ Discord for development/support/play: https://discord.gg/5XuDkje
 
 ## Important notice
 
-This is the development branch for factorioClusterio 2.0 which is currently undergoing heavy
-restructuring and refactoring.  Expect plugins and existing installations to frequently break when
-using this branch.  If you don't want to be an alpha tester for 2.0 please use the stable
-[1.2.x branch][1.2.x] or
-[latest stable release](https://github.com/clusterio/factorioClusterio/releases/latest).
+This is the development branch for factorioClusterio 2.0 which is currently undergoing heavy restructuring and refactoring.
+Expect plugins and existing installations to frequently break when using this branch.
+If you don't want to be an alpha tester for 2.0 please use the stable [1.2.x branch][1.2.x] or [latest stable release](https://github.com/clusterio/factorioClusterio/releases/latest).
 
-Installation instructions below are for the unstable master branch.  Go to the page for
-the [1.2.x branch][1.2.x] for instructions on how to install the stable version.
+Installation instructions below are for the unstable master branch.
+Go to the page for the [1.2.x branch][1.2.x] for instructions on how to install the stable version.
 
 [1.2.x]: https://github.com/clusterio/factorioClusterio/tree/1.2.x
 
 ### Ways to support me/the project:
 
-* Contribute with code/documentation. See [Contributing](docs/contributing.md) for how to make pull
-  requests.  Always nice to move the project forward.
+* Contribute with code/documentation.
+  See [Contributing](docs/contributing.md) for how to make pull requests.
+  Always nice to move the project forward.
 
 * Support me monetarily on [patreon](https://www.patreon.com/danielv123) or paypal: danielv@live.no
 
@@ -48,74 +47,54 @@ the [1.2.x branch][1.2.x] for instructions on how to install the stable version.
 
 ## Introduction
 
-Clusterio is a clustered Factorio server manager that provides the
-tooling for implementing cross server interactions in Factorio.  It
-was previously best known for implementing cross server transfer and
-cloud storage of items via teleporter chests.  But this functionality
-has been pulled out of Clusterio into its own plugin for Clusterio named
-[Subspace Storage](https://github.com/clusterio/factorioClusterioMod).
+Clusterio is a clustered Factorio server manager that provides the tooling for implementing cross server interactions in Factorio.
+It was previously best known for implementing cross server transfer and cloud storage of items via teleporter chests.
+But this functionality has been pulled out of Clusterio into its own plugin for Clusterio named [Subspace Storage](https://github.com/clusterio/factorioClusterioMod).
 
-By itself Clusterio doesn't change the gameplay in any way, you could
-even use Clusterio to manage completely vanilla Factorio servers.
-Plugins do the work of modding in the visible changes into the game, see
-the [Plugins section](#plugins) for ready made plugins you can install
-into a Clusterio cluster.
+By itself Clusterio doesn't change the gameplay in any way, you could even use Clusterio to manage completely vanilla Factorio servers.
+Plugins do the work of modding in the visible changes into the game, see the [Plugins section](#plugins) for ready made plugins you can install into a Clusterio cluster.
 
 
 ## Features
 
-- Clustered Factorio server management allowing you manage the running
-  of Factorio servers across a fleet of physical servers from both a web
-  interface and a command line interface.
+- Clustered Factorio server management allowing you manage the running of Factorio servers across a fleet of physical servers from both a web interface and a command line interface.
 
-- User list management for synchronizing in-game admins, whitelisted
-  users, and bans to all the servers in the cluster.
+- User list management for synchronizing in-game admins, whitelisted users, and bans to all the servers in the cluster.
 
-- Integrated support for exporting statistics for the whole cluster to
-  Prometheus via a single metrics endpoint.
+- Integrated support for exporting statistics for the whole cluster to Prometheus via a single metrics endpoint.
 
-- Extensive plugin support for adding your own cross server features to
-  Factorio using Clusterio's communication backbone.
+- Extensive plugin support for adding your own cross server features to Factorio using Clusterio's communication backbone.
 
 
 ## Plugins
 
-The heart of Clusterio is its plugin system.  Plugins add functionality
-to Factorio servers, Clusterio itself or both.  These are the plugins
-supported and maintained by the Clusterio developers:
+The heart of Clusterio is its plugin system.
+Plugins add functionality to Factorio servers, Clusterio itself or both.
+These are the plugins supported and maintained by the Clusterio developers:
 
-- [Global Chat](/plugins/global_chat/README.md): share the in-game chat
-  between servers.
-- [Research Sync](/plugins/research_sync/README.md): synchronize
-  research progress and technologies unlocked between servers.
-- [Statistics Exporter](/plugins/statistics_exporter/README.md): collect
-  in-game statistics from all the servers and makes it available to the
-  Prometheus endpoint on the master server.
-- [Subspace Storage](https://github.com/clusterio/factorioClusterioMod):
-  Provide shared storage that can transport items between servers via
-  teleport chests.
-- [Player Auth](/plugins/player_auth/README.md): Provides authentication
-  to the cluster via logging into a Factorio server.
+- [Global Chat](/plugins/global_chat/README.md): share the in-game chat between servers.
+- [Research Sync](/plugins/research_sync/README.md): synchronize research progress and technologies unlocked between servers.
+- [Statistics Exporter](/plugins/statistics_exporter/README.md): collect in-game statistics from all the servers and makes it available to the Prometheus endpoint on the master server.
+- [Subspace Storage](https://github.com/clusterio/factorioClusterioMod): Provide shared storage that can transport items between servers via teleport chests.
+- [Player Auth](/plugins/player_auth/README.md): Provides authentication to the cluster via logging into a Factorio server.
 
 There's also plugins developed and maintained by the community:
 
-- [Discord Bridge](https://github.com/Hornwitser/discord_bridge):
-  Bridges chat between instances and Discord.  By Hornwitser.
-- [Server Select](https://github.com/Hornwitser/server_select):
-  In-game GUI for connecting to other server in the cluster.  Originally
-  by Godmave, ported to 2.0 by Hornwitser.
+- [Discord Bridge](https://github.com/Hornwitser/discord_bridge): Bridges chat between instances and Discord.
+  By Hornwitser.
+- [Server Select](https://github.com/Hornwitser/server_select): In-game GUI for connecting to other server in the cluster.
+  Originally by Godmave, ported to 2.0 by Hornwitser.
 
-Want to make your own plugin?  Check out the documentation on [Writing
-Plugins](/docs/writing-plugins.md) for where to start.
+Want to make your own plugin?
+Check out the documentation on [Writing Plugins](/docs/writing-plugins.md) for where to start.
 
 
 ## Ubuntu setup
 
-**Warning**: These instructions are for the unstable master version and is not
-recommended for use, see [the 1.2.x branch][1.2.x] for how to install the stable version.
+**Warning**: These instructions are for the unstable master version and is not recommended for use, see [the 1.2.x branch][1.2.x] for how to install the stable version.
 
-Clusterio runs on Node.js v12 and up, and v10.16.0+.  Node.js itself is not
-supported on EOL Ubuntu releases so make sure you're on a recent release of Ubuntu.
+Clusterio runs on Node.js v12 and up, and v10.16.0+.
+Node.js itself is not supported on EOL Ubuntu releases so make sure you're on a recent release of Ubuntu.
 
 Master and all slaves:
 
@@ -128,12 +107,13 @@ Master and all slaves:
     wget -O factorio.tar.gz https://www.factorio.com/get-download/latest/headless/linux64
     tar -xf factorio.tar.gz
 
-downloads and installs nodejs, git and clusterio. To specify a version, change "latest" in the link to a version number like 0.14.21.
+downloads and installs nodejs, git and clusterio.
+To specify a version, change "latest" in the link to a version number like 0.14.21.
 
 **Ubuntu with Docker**
 
-The Docker support for Clusterio is curently broken.  If you need it
-open an issue about it.
+The Docker support for Clusterio is curently broken.
+If you need it open an issue about it.
 
 <!--
 Clusterio has *very* limited support for using docker.
@@ -144,18 +124,18 @@ Clusterio has *very* limited support for using docker.
 
 	sudo docker run --name slave -e MODE=slave -e INSTANCE=world1 -v /srv/clusterio/instances:/factorioClusterio/instances -p 1235:34167 -it --restart=unless-stopped danielvestol/clusterio
 
-The -v flag is used to specify the instance directory. Your instances (save files etc) will be stored there.
+The -v flag is used to specify the instance directory.
+Your instances (save files etc) will be stored there.
 -->
 
 ## Windows setup
 
-**Warning**: These instructions are for the unstable master version and is not
-recommended for use, see [the 1.2.x branch][1.2.x] for how to install the stable version.
+**Warning**: These instructions are for the unstable master version and is not recommended for use, see [the 1.2.x branch][1.2.x] for how to install the stable version.
 
 **Requirements**
 
-download and install nodeJS 12 from http://nodejs.org.  Clusterio runs on Node.js v12 and
-up, and v10.16.0+.
+download and install nodeJS 12 from http://nodejs.org.
+Clusterio runs on Node.js v12 and up, and v10.16.0+.
 
 **Master**
 
@@ -170,31 +150,25 @@ up, and v10.16.0+.
 
     - Via the stand alone version on from their website
 
-        1.  Create a new folder named "factorio" in the the factorioClusterio
-            folder.
+        1.  Create a new folder named "factorio" in the the factorioClusterio folder.
 
-        2.  Download the MS Windows (64-bit zip package) from
-            https://www.factorio.com/download .
+        2.  Download the MS Windows (64-bit zip package) from https://www.factorio.com/download .
 
-        3.  Open the zip file and drag the folder called "Factorio_x.y.z" into
-            the factorio folder created in step 1.
+        3.  Open the zip file and drag the folder called "Factorio_x.y.z" into the factorio folder created in step 1.
 
     - Via steam installation
 
-        1.  Create a new folder named "factorio" in the the factorioClusterio
-            folder.
+        1.  Create a new folder named "factorio" in the the factorioClusterio folder.
 
-        2.  Locate the game files by right clicking the game in steam,
-            selecting properties, then Local Files, then Browse local files.
+        2.  Locate the game files by right clicking the game in steam, selecting properties, then Local Files, then Browse local files.
 
-        3.  Go to the parent folder of the folder that Steam opened and copy
-            the Factorio folder into the factorio folder created in step 1.
+        3.  Go to the parent folder of the folder that Steam opened and copy the Factorio folder into the factorio folder created in step 1.
 
 
 ## Installing Plugins
 
-Installing plugins to make them work with Clusterio consists of two
-steps.  First install the package via npm, for example
+Installing plugins to make them work with Clusterio consists of two steps.
+First install the package via npm, for example
 
     npm install @clusterio/plugin-subspace_storage
 
@@ -202,22 +176,17 @@ Then tell clusterio that this plugin exists by adding it as a plugin.
 
     npx clusteriomaster plugin add @clusterio/plugin-subspace_storage
 
-This adds it to the default `plugin-list.json` file which in the shared
-folder setup is loaded by master, slave and ctl.  If you have slaves or
-ctl installed on separate computers (or directories) then you need to
-repeat the plugin install process for all of them.  The clusteriomaster,
-clusterioslave and clusterioctl commands has the plugin sub-command
-so you do not need to install clusteriomaster to add plugins.
+This adds it to the default `plugin-list.json` file which in the shared folder setup is loaded by master, slave and ctl.
+If you have slaves or ctl installed on separate computers (or directories) then you need to repeat the plugin install process for all of them.
+The clusteriomaster, clusterioslave and clusterioctl commands has the plugin sub-command so you do not need to install clusteriomaster to add plugins.
 
-For development purposes the `plugin add` command supports adding
-plugins by the absolute path to them, or a relative path that must start
-with either . or .. (which will then be resolved to an absolute path).
+For development purposes the `plugin add` command supports adding plugins by the absolute path to them, or a relative path that must start with either . or .. (which will then be resolved to an absolute path).
 
 
 ## Configure Master Server
 
-By default the master server will listen for HTTP on port 8080.  You can
-change the port used with the command
+By default the master server will listen for HTTP on port 8080.
+You can change the port used with the command
 
     npx clusteriomaster config set master.http_port 1234
 
@@ -226,67 +195,50 @@ that it will be accessible under with, for example
 
     npx clusteriomaster config set master.external_address http://203.0.113.4:1234/
 
-Change the url to reflect the IP, protocol, and port the master server
-is accessible under, dns names are also supported.  If you're planning
-on making the master server accessible on the internet it's recommended
-to set up TLS, see the [Setting Up TLS](/docs/setting-up-tls.md)
-document for more details.
+Change the url to reflect the IP, protocol, and port the master server is accessible under, dns names are also supported.
+If you're planning on making the master server accessible on the internet it's recommended to set up TLS, see the [Setting Up TLS](/docs/setting-up-tls.md) document for more details.
 
-You can list the config of the master server with the `npx
-clusteriomaster config list` command.  See the [readme for
-@clusterio/master](/packages/master/README.md) for more
-information.
+You can list the config of the master server with the `npx clusteriomaster config list` command.
+See the [readme for @clusterio/master](/packages/master/README.md) for more information.
 
 
 ### Setting up an admin account
 
-Before you can manage the cluster you need to bootstrap an admin account
-for it.  Replace `<username>` with your Factorio username (do not make
-up a new username here).
+Before you can manage the cluster you need to bootstrap an admin account for it.
+Replace `<username>` with your Factorio username (do not make up a new username here).
 
     npx clusteriomaster bootstrap create-admin <username>
     npx clusteriomaster bootstrap create-ctl-config <username>
 
-The first command creates a user account with the given name and
-promotes it to a cluster admin.  The second one sets up a
-`config-control.json` config for clusterioctl to connect to the master
-server under the given user account.
+The first command creates a user account with the given name and promotes it to a cluster admin.
+The second one sets up a `config-control.json` config for clusterioctl to connect to the master server under the given user account.
 
 
 ## Running Clusterio
 
-After following the installation and master configuration instructions
-you can use the following commands to run Clusterio.
+After following the installation and master configuration instructions you can use the following commands to run Clusterio.
 
 
 ### Master Server
 
 It's necessary to run the master server in order for anything to work.
-Once you've completed the setup run the following command to start it
-up:
+Once you've completed the setup run the following command to start it up:
 
     npx clusteriomaster run
 
 
 ### Slaves
 
-Slaves connect to the master server and are managed remotely from the
-master server.  In order for slaves to connect to the master server they
-need a valid authentication token, you can create a slave config with
-a valid token with the following command.
+Slaves connect to the master server and are managed remotely from the master server.
+In order for slaves to connect to the master server they need a valid authentication token, you can create a slave config with a valid token with the following command.
 
     npx clusterioctl slave create-config --name Local --generate-token
 
-This will write a new `config-slave.json` file in the current directory
-(you can change the location with the `--output` option) with the name,
-token and url to connect to the master server with.  If you are making
-the config for a remote slave you will need to have set the
-`master.external_address` option to the URL the master server can be
-reached on.
+This will write a new `config-slave.json` file in the current directory (you can change the location with the `--output` option) with the name, token and url to connect to the master server with.
+If you are making the config for a remote slave you will need to have set the `master.external_address` option to the URL the master server can be reached on.
 
-You can list the config of a slave on the slave itself with the `npx
-clusterioslave config list` command.  See the [readme for
-@clusterio/slave](/packages/slave/README.md) for more information.
+You can list the config of a slave on the slave itself with the `npx clusterioslave config list` command.
+See the [readme for @clusterio/slave](/packages/slave/README.md) for more information.
 
 Once the config is set up run the slave with
 
@@ -295,13 +247,9 @@ Once the config is set up run the slave with
 
 ### Instances
 
-Instances are created, managed and started from the master server.  For
-now the only interface available is the `clusterioctl` command line tool
-included in Clusterio.  You can run this tool from any slave, or the
-master server without having to set up a config, if you want to manage
-the cluster from somewhere else you will need to set the
-`control.master_url` and `control.master_token` options with the  `node
-clusterioctl control-config set` command:
+Instances are created, managed and started from the master server.
+For now the only interface available is the `clusterioctl` command line tool included in Clusterio.
+You can run this tool from any slave, or the master server without having to set up a config, if you want to manage the cluster from somewhere else you will need to set the `control.master_url` and `control.master_token` options with the  `node clusterioctl control-config set` command:
 
 The basic operations to start a new instance is the following
 
@@ -310,21 +258,19 @@ The basic operations to start a new instance is the following
     npx clusterioctl instance start "My instance"
 
 The first line creates the instance configuration on the master server.
-The second assigns the instance to a slave which creates the instance
-directory and files needed to run the instance on the given slave.  The
-third line starts the instance, which creates a new save if there are no
-save games present.
+The second assigns the instance to a slave which creates the instance directory and files needed to run the instance on the given slave.
+The third line starts the instance, which creates a new save if there are no save games present.
 
-There are many more commands available with clusterioctl.  See the
-[Managing a Cluster](/docs/managing-a-cluster.md) document or
-`npx clusterioctl --help` for a full list of them.
+There are many more commands available with clusterioctl.
+See the [Managing a Cluster](/docs/managing-a-cluster.md) document or `npx clusterioctl --help` for a full list of them.
 
 
 ## Common problems
 
 ### EACCESS [...] LISTEN 443
 
-Some systems don't let non root processes listen to ports below 1000. Either run with `sudo` or change config.json to use higher port numbers.
+Some systems don't let non root processes listen to ports below 1000.
+Either run with `sudo` or change config.json to use higher port numbers.
 
 According to [this link](https://askubuntu.com/questions/839520/open-port-443-for-a-node-web-app) if you manually installed node.js following the above instructions, you may need to run the following command to fix this issue:
 
@@ -332,7 +278,11 @@ According to [this link](https://askubuntu.com/questions/839520/open-port-443-fo
 
 ### Portforwarding doesn't work on the master server when running under WSL
 
-If you follow the ubuntu guide on WSL (Windows Subsystem for Linux, Bash on Ubuntu on Windows specifically), you will find that the website works on localhost and on your local ip, but not on the global ip. This is also true when you correctly port-forwarded the correct ports. Even when routing this server through nginx in WSL, the issue persists. Then, on a hunch, I tried to run nginx from windows itself and found that this DID work. It came to me that the only usage difference between the 2 versions of nginx is that I got a Windows Firewall popup.
+If you follow the ubuntu guide on WSL (Windows Subsystem for Linux, Bash on Ubuntu on Windows specifically), you will find that the website works on localhost and on your local ip, but not on the global ip.
+This is also true when you correctly port-forwarded the correct ports.
+Even when routing this server through nginx in WSL, the issue persists.
+Then, on a hunch, I tried to run nginx from windows itself and found that this DID work.
+It came to me that the only usage difference between the 2 versions of nginx is that I got a Windows Firewall popup.
 
 TLDR: the tested fix is:
 

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -1,59 +1,36 @@
-Communication Layer
-===================
+# Communication Layer
 
-<sub>This document describes the communication layer in Clusterio and
-unless you're developing Clusterio it's probably not going to be very
-useful for you.</sub>
+<sub>This document describes the communication layer in Clusterio and unless you're developing Clusterio it's probably not going to be very useful for you.</sub>
 
-Communication is facilitated by the lib/link library and is based on
-three core abstractions: links, connectors and messages.  Links
-represents one side of a two way communication pipe, connectors deal
-with connecting and establishing communication, and messages are the
-content sent over the link.
+Communication is facilitated by the lib/link library and is based on three core abstractions: links, connectors and messages.
+Links represents one side of a two way communication pipe, connectors deal with connecting and establishing communication, and messages are the content sent over the link.
 
 
-Link
-----
+## Link
 
-The Link class represents one side of a two way communication channel
-where the actual communication is done by a connector associated with
-the link.  The link also knows what the endpoint types it's connected to
-are via the source and target attributes.
+The Link class represents one side of a two way communication channel where the actual communication is done by a connector associated with the link.
+The link also knows what the endpoint types it's connected to are via the source and target attributes.
 
-The endpoint types currently implemented are master, slave, instance,
-and control.  Although slave and instances run in the same Node.js
-program they use virtual links to communicate between them in order to
-simplify the communication architecture.
+The endpoint types currently implemented are master, slave, instance, and control.
+Although slave and instances run in the same Node.js program they use virtual links to communicate between them in order to simplify the communication architecture.
 
-Upon creation the link will register with the connector in order to
-receive and process messages from it.  The messages received are
-validated using the validator registered for the type of the message.  A
-message for which there is no validator for is considered an error.
+Upon creation the link will register with the connector in order to receive and process messages from it.
+The messages received are validated using the validator registered for the type of the message.
+A message for which there is no validator for is considered an error.
 
 
-Connector
----------
+## Connector
 
-The connector used with a link is responsible for establishing and/or
-maintain the connection that messages are sent over.  Reconnect logic is
-expected to be implemented in the connector, though this has not yet
-been done.
+The connector used with a link is responsible for establishing and/or maintain the connection that messages are sent over.
+Reconnect logic is expected to be implemented in the connector, though this has not yet been done.
 
-There's also the virtual connector which lets two links in the same
-program be connected to each other without having to establish a
-network connection.
+There's also the virtual connector which lets two links in the same program be connected to each other without having to establish a network connection.
 
 
-Message
--------
+## Message
 
-There's two types of messages currently implemented apart from the
-Link builtin close message and that's Request and Event.  The builtin
-messages are defined in
-[packages/lib/link/messages.js](/packages/lib/link/messages.js) and are
-attached to links via the attachAllMessages function, which is usally
-called in the Link subclass constructor.
+There's two types of messages currently implemented apart from the Link builtin close message and that's Request and Event.
+The builtin messages are defined in [packages/lib/link/messages.js](/packages/lib/link/messages.js) and are attached to links via the attachAllMessages function, which is usally called in the Link subclass constructor.
 
-The messages define which links they are valid on and only attaches
-handlers for those links.  There's also a forwarding mechanism for when
-a request or event is to be forwarded another hop.
+The messages define which links they are valid on and only attaches handlers for those links.
+There's also a forwarding mechanism for when a request or event is to be forwarded another hop.

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -1,55 +1,34 @@
-Configuration System
-====================
+# Configuration System
 
-<sub>This document describes the implementation and inner working of the
-configuration system in Clusterio, and unless you're developing
-Clusterio it's probably not going to be very useful for you.</sub>
+<sub>This document describes the implementation and inner working of the configuration system in Clusterio, and unless you're developing Clusterio it's probably not going to be very useful for you.</sub>
 
-Clusterio uses a group based configuration system to manage settings for
-the master server, instances, slaves, and the clusterioctl utility.
-Plugins get their own config group for the master server and instances
-which they can add their own fields to.  The fields are defined early in
-the startup, and the groups and their fields for disabled plugins will
-still be created.
+Clusterio uses a group based configuration system to manage settings for the master server, instances, slaves, and the clusterioctl utility.
+Plugins get their own config group for the master server and instances which they can add their own fields to.
+The fields are defined early in the startup, and the groups and their fields for disabled plugins will still be created.
 
-The built-in config groups and their fields are defined in
-[packages/lib/config/definitions.js](/packages/lib/config/definitions.js)
-while plugins can add their own config groups to the `MasterConfigGroup`
-and `InstanceConfigGroup` properties of the `info.js` export using
-subclasses of `PluginConfigGroup`.  The plugin group has the enabled
-field pre-defined on it, and it's used to enable/disable plugins.
+The built-in config groups and their fields are defined in [packages/lib/config/definitions.js](/packages/lib/config/definitions.js) while plugins can add their own config groups to the `MasterConfigGroup` and `InstanceConfigGroup` properties of the `info.js` export using subclasses of `PluginConfigGroup`.
+The plugin group has the enabled field pre-defined on it, and it's used to enable/disable plugins.
 
 
-Defing Fields
--------------
+## Defing Fields
 
-Fields are defined using the `define` class method on group classes
-after the groupName have been set and before the class has been
-finalized.  The `define` method takes an object as argument with the
-following properties:
+Fields are defined using the `define` class method on group classes after the groupName have been set and before the class has been finalized.
+The `define` method takes an object as argument with the following properties:
 
 **access**:
-    The locations this config field can be read and modified from.  This
-    is an array of strings which can contain the values `"master"`,
-    `"slave"` and `"control"`.  If a party is missing in this array then
-    that party will not receive the value of this field when the config
-    is shared, and will be unable to modify the field.  Takes the value
-    of `defaultAccess` set on the config group class if not passed.
-    Note that instance config groups should have both `"master"` and
-    `"slave"` for all of its fields or unexpected behaviour may occur.
+    The locations this config field can be read and modified from.
+    This is an array of strings which can contain the values `"master"`, `"slave"` and `"control"`.
+    If a party is missing in this array then that party will not receive the value of this field when the config is shared, and will be unable to modify the field.
+    Takes the value of `defaultAccess` set on the config group class if not passed.
+    Note that instance config groups should have both `"master"` and `"slave"` for all of its fields or unexpected behaviour may occur.
 
 **type**:
-    The type of config value this field will support.  The supported
-    values are boolean, string, number, and object, and if an attept is
-    made to set the field to a value that is not of the right type it
-    will be reject unless it's a string that can be converted to the
-    right type.
+    The type of config value this field will support.
+    The supported values are boolean, string, number, and object, and if an attept is made to set the field to a value that is not of the right type it will be reject unless it's a string that can be converted to the right type.
 
 **name**:
-    Name of the configuration field, this is the primary way the field
-    is accessed, both in code and on the command line.  As such it
-    should follow the lower\_case\_underscore style and not contain any
-    spaces or dots.
+    Name of the configuration field, this is the primary way the field is accessed, both in code and on the command line.
+    As such it should follow the lower\_case\_underscore style and not contain any spaces or dots.
 
 **title** (optional):
     Text used to identify the config field in user interfaces.
@@ -58,27 +37,24 @@ following properties:
     Text used to describe the config field in user interfaces.
 
 **enum** (optional):
-    Array of acceptable values this field can have.  Attempts to set a
-    value not in this array will be rejected, which makes it useful for
-    making enumareted list of choices.
+    Array of acceptable values this field can have.
+    Attempts to set a value not in this array will be rejected, which makes it useful for making enumareted list of choices.
 
 **optional** (optional):
-    True if this field can be set to null.  Defaults to false.
+    True if this field can be set to null.
+    Defaults to false.
 
 **initial_value** (optional if optional is true):
     Value this config field should take in a newly initialized config.
     This can also be an async function returning the value to use.
 
-If the value for a field stored in on disk somehow ends up being invalid
-the field will take on the initial\_value instead when the config is
-loaded.
+If the value for a field stored in on disk somehow ends up being invalid the field will take on the initial\_value instead when the config is loaded.
 
 
-Accessing Fields
-----------------
+## Accessing Fields
 
-On the Config instance there's two ways to access fields:  through the
-set and get methods using dot notation.  E.g.:
+On the Config instance there's two ways to access fields: through the set and get methods using dot notation.
+E.g.:
 
     let value = configInstance.get("group.field");
 
@@ -87,26 +63,16 @@ E.g.:
 
     let value = configInstance.group("group").get("field")
 
-The set method takes an extra argument, which is the value to set the
-field to.  If the value is not valid this will throw an InvalidValue
-exception, if the group or field doesn't exist it will throw an
-InvalidField exception.
+The set method takes an extra argument, which is the value to set the field to.
+If the value is not valid this will throw an InvalidValue exception, if the group or field doesn't exist it will throw an InvalidField exception.
 
 
-Config Lifecycle
-----------------
+## Config Lifecycle
 
-Values for all config fields are created when the config is initialized,
-as well as for any fields with missing values when a config is loaded.
-Once a field has a value it is never automatically removed, even if the
-field or group it was part of no longer exists.  This ensures that
-plugin configuration is not lost should the server be started up without
-the plugins that defined the configuration installed.
+Values for all config fields are created when the config is initialized, as well as for any fields with missing values when a config is loaded.
+Once a field has a value it is never automatically removed, even if the field or group it was part of no longer exists.
+This ensures that plugin configuration is not lost should the server be started up without the plugins that defined the configuration installed.
 
-For instance configs, they are kept on the master server and serialized
-and sent over to the relevant slaves on startup.  This makes it possible
-to edit instance configs when the slave the instance is on is offline.
-A copy is also stored in the instance directory on the slave, and this
-config will be deliverd to the master server on slave startup, which
-enables instances to be copied between clusters as long as their IDs are
-unique.
+For instance configs, they are kept on the master server and serialized and sent over to the relevant slaves on startup.
+This makes it possible to edit instance configs when the slave the instance is on is offline.
+A copy is also stored in the instance directory on the slave, and this config will be deliverd to the master server on slave startup, which enables instances to be copied between clusters as long as their IDs are unique.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,54 +1,51 @@
-Configuration
-=============
+# Configuration
 
 
-Master Configuration
---------------------
+## Master Configuration
 
 ### master.name
 
-Name of the cluster.  Used to distinguish it from other clusters and is
-prepended to the name of servers in the server list.
+Name of the cluster.
+Used to distinguish it from other clusters and is prepended to the name of servers in the server list.
 
 Defaluts to "Your Cluster".
 
 
 ### master.database_directory
 
-Directory used to store cluster data to.  Needs to be writeable by the
-master server.  This is also used by plugins to store its data.
+Directory used to store cluster data to.
+Needs to be writeable by the master server.
+This is also used by plugins to store its data.
 
 Defaults to "database".
 
 
 ### master.http_port
 
-Port to host HTTP server on.  If set to null no HTTP server will be
-exposed.  At least one of this and master.https_port needs to be set to
-a port.
+Port to host HTTP server on.
+If set to null no HTTP server will be exposed.
+At least one of this and master.https_port needs to be set to a port.
 
 Defaults to 8080.
 
 
 ### master.https_port
 
-Port to host HTTPS server on.  Uses master.tls_certificate and
-master.tls_private_key as the certificate and private key for the HTTPS
-server.  If set to null no HTTPS server will be exposed.  At least one
-of this and master.http_port needs to be set to a port.
+Port to host HTTPS server on.
+Uses master.tls_certificate and master.tls_private_key as the certificate and private key for the HTTPS server.
+If set to null no HTTPS server will be exposed.
+At least one of this and master.http_port needs to be set to a port.
 
-See the [Setting up TLS](/docs/setting-up-tls.md) document for a guide
-to setting up HTTPS with Clusterio.
+See the [Setting up TLS](/docs/setting-up-tls.md) document for a guide to setting up HTTPS with Clusterio.
 
 Defaults to null.
 
 
 ### master.bind_address
 
-IP address to bind the HTTP and HTTPS ports on.  Useful to limit which
-interface to accept connections from.  If set to null the unspecified
-IPv6 address will be used, which on most systems means it will also
-listen on the unspecified IPv4 address and accept connections from all
+IP address to bind the HTTP and HTTPS ports on.
+Useful to limit which interface to accept connections from.
+If set to null the unspecified IPv6 address will be used, which on most systems means it will also listen on the unspecified IPv4 address and accept connections from all
 interfaces.
 
 Defaults to null.
@@ -56,122 +53,107 @@ Defaults to null.
 
 ### master.external_address
 
-External address the master server is accessible on.  Currently only
-used for `clusteriomaster bootstrap create-ctl-config` in order to give
-the right url to connect to.  This should be a full URL ending with a /.
+External address the master server is accessible on.
+Currently only used for `clusteriomaster bootstrap create-ctl-config` in order to give the right url to connect to.
+This should be a full URL ending with a /.
 
 Defaults to null meaning assume localhost.
 
 
 ### master.tls_certificate
 
-Path to TLS certificate to use for the HTTPS server when
-master.https_port is configured.
+Path to TLS certificate to use for the HTTPS server when master.https_port is configured.
 
 Defaults to "database/certificates/cert.crt".
 
 
 ### master.tls_private_key
 
-Path to TLS private key to use for the HTTPS server when
-master.https_port is configured.
+Path to TLS private key to use for the HTTPS server when master.https_port is configured.
 
 Defaults to "database/certificates/cert.key".
 
 
 ### master.auth_secret
 
-Base64 encoded authentication secret used to verify tokens issued to
-slaves, users, and sessions.  This should contain 256 bytes of random
-data, and if changed will cause all tokens become invalid.  Keep this
-secret if leaked an attacker could easily compromise the cluster.
+Base64 encoded authentication secret used to verify tokens issued to slaves, users, and sessions.
+This should contain 256 bytes of random data, and if changed will cause all tokens become invalid.
+Keep this secret if leaked an attacker could easily compromise the cluster.
 
 Defaults to null which means generate a secure secret on startup.
 
 
 ### master.heartbeat_interval
 
-Interval in seconds heartbeats are sent out at for WebSocket
-connections.  If a connection hasn't received a heartbeat in 2 times the
-heartbeat interval it will be considered stale and closed.  A lower
-value means less time between connections going stale and them being
-closed.
+Interval in seconds heartbeats are sent out at for WebSocket connections.
+If a connection hasn't received a heartbeat in 2 times the heartbeat interval it will be considered stale and closed.
+A lower value means less time between connections going stale and them being closed.
 
-Defaults to 45
+Defaults to 45.
 
 
 ### master.connector_shutdown_timeout
 
-Timeout in seconds to use while shutting down the master server for link
-sessions that currently don't have an active connection and haven't been
-closed down properly.  This happens when the network between a slave and
-the master server goes down unexpectedly, or the slave goes down without
-closing the connection properly either do to crashing or the machine
-it's hosted on going down.  If the timeout expires the session is
-terminated and data loss may occur, if the slave went down this is
-unavoidable.
+Timeout in seconds to use while shutting down the master server for link sessions that currently don't have an active connection and haven't been closed down properly.
+This happens when the network between a slave and the master server goes down unexpectedly, or the slave goes down without closing the connection properly either do to crashing or the machine it's hosted on going down.
+If the timeout expires the session is terminated and data loss may occur, if the slave went down this is unavoidable.
 
 Defaults to 30.
 
 
 ### master.metrics_timeout
 
-Timeout in seconds before a call to gather metrics from a slave times
-out.  This should be less than both the timeout and collection interval
-configured for the collection job in Prometheus.
+Timeout in seconds before a call to gather metrics from a slave times out.
+This should be less than both the timeout and collection interval configured for the collection job in Prometheus.
 
 Defaults to 8.
 
 
 ### master.default_role_id
 
-Role to automatically grant to new users.  If null no role is granted.
+Role to automatically grant to new users.
+If null no role is granted.
 
 Defaults to 1 which correspond to the default Player role.
 
 
 ### <plugin_name>.load_plugin
 
-Whether to load the plugin on the master server.  Plugins not loaded on
-the master server will not be loaded on instances.
+Whether to load the plugin on the master server.
+Plugins not loaded on the master server will not be loaded on instances.
 
 Defaults to true.
 
 
-Slave Configuration
--------------------
+## Slave Configuration
 
 ### slave.name
 
-Name of the slave.  Shows up in slave lists and is used to reference
-this slave in the clusterioctl command line interface.
+Name of the slave.
+Shows up in slave lists and is used to reference this slave in the clusterioctl command line interface.
 
 Defaults to "New Slave".
 
 
 ### slave.id
 
-Immutable numeric id of the slave which uniquely identifies this slave in
-the cluster.
+Immutable numeric id of the slave which uniquely identifies this slave in the cluster.
 
 Defaults to a random 31 bit number.
 
 
 ### slave.factorio_directory
 
-Directory to look for the Factorio server(s) in.  This can either point
-to a Factorio server directory, or to a directory containing multiple
-versions of the Factorio server.
+Directory to look for the Factorio server(s) in.
+This can either point to a Factorio server directory, or to a directory containing multiple versions of the Factorio server.
 
 Defaults to "factorio".
 
 
 ### slave.instances_directory
 
-Directory to store instances in.  One sub-directory will be created in
-it for each instance assigned to this slave and these sub-directories
-will contain logs, saves, and various auto generated configuration files
-for the instances.
+Directory to store instances in.
+One sub-directory will be created in it for each instance assigned to this slave and these sub-directories will contain logs, saves, and various auto generated configuration files for the instances.
 
 Defaults to "instances".
 
@@ -185,164 +167,140 @@ Defaults to "http://localhost:8080/".
 
 ### slave.master_token
 
-Access token used for authenticating with the master server.  You can
-generate an access token with `clusterioctl slave generate-token
---id <slave-id>`, or use the `clusterioctl slave create-config` to
-create a new slave config with the correct url and token in it.
+Access token used for authenticating with the master server.
+You can generate an access token with `clusterioctl slave generate-token --id <slave-id>`, or use the `clusterioctl slave create-config` to create a new slave config with the correct url and token in it.
 
 Defaults to "enter token here".
 
 
 ### slave.tls_ca
 
-Path to certificate in PEM format to use for validating a TLS connection
-to the master server.  If you have a self signed certificate on the
-master server you will need to copy the certificate to your slaves and
-set it as the certificate authority with this option.
+Path to certificate in PEM format to use for validating a TLS connection to the master server.
+If you have a self signed certificate on the master server you will need to copy the certificate to your slaves and set it as the certificate authority with this option.
 
-Defaults to null meaning use Node.js's default set of trusted
-certificate authorities.
+Defaults to null meaning use Node.js's default set of trusted certificate authorities.
 
 
 ### slave.public_address
 
 External address instances hosted on this slave can be accessed on.
-This is used by plugins like Server Select to give the correct address
-to switch between instances in-game.
+This is used by plugins like Server Select to give the correct address to switch between instances in-game.
 
 Defaults to "localhost".
 
 
 ### slave.reconnect_delay
 
-Delay in seconds to wait after connection to the master server is
-dropped before attempting to reconnect to it.  The actual delay on each
-reconnect will be a random number between 0 and this configured value to
-avoid all slaves trying to reconnect at the same time.
+Delay in seconds to wait after connection to the master server is dropped before attempting to reconnect to it.
+The actual delay on each reconnect will be a random number between 0 and this configured value to avoid all slaves trying to reconnect at the same time.
 
 Defaults to 5.
 
 
-Instance Configuration
-----------------------
+## Instance Configuration
 
 ### instance.name
 
-Name of the instance, shown in instance lists and used to reference to this
-instance in the clusterioctl command line interface.
+Name of the instance, shown in instance lists and used to reference to this instance in the clusterioctl command line interface.
 
-Defaults to "New Instance"
+Defaults to "New Instance".
 
 
 ### instance.id
 
-Imutable numeric id of the instance which uniquely identifies this
-instance in the cluster.
+Imutable numeric id of the instance which uniquely identifies this instance in the cluster.
 
 Defaluts to a random 31 bit integer.
 
 
 ### instance.assigned_slave
 
-Slave this instance is assigned to.  To change this you need to use the
-separate assign instance interface.  After being assigned to a slave the
-directory for the instance is created on the slave.
+Slave this instance is assigned to.
+To change this you need to use the separate assign instance interface.
+After being assigned to a slave the directory for the instance is created on the slave.
 
 Defaults to null meaning not assigned.
 
 
 ### instance.auto_start
 
-If enabled start this instance when the slave it is assigned to is
-started up.  Does not affect start or stop of the instance while the
-slave is running.
+If enabled start this instance when the slave it is assigned to is started up.
+Does not affect start or stop of the instance while the slave is running.
 
-Defaults to false
+Defaults to false.
 
 
 ### factorio.version
 
-Version of Factorio to use for this instance.  Can be a version like
-"1.0.0" or special string "latest" meaning the latest version of
-Factorio found on the slave.
+Version of Factorio to use for this instance.
+Can be a version like "1.0.0" or special string "latest" meaning the latest version of Factorio found on the slave.
 
-Defaults to "latest"
+Defaults to "latest".
 
 
 ### factorio.game_port
 
-UDP port to run the Factorio server on.  If null a random port in the
-dynamyc range assigned each time the instance starts.
+UDP port to run the Factorio server on.
+If null a random port in the dynamyc range assigned each time the instance starts.
 
-Defaults to null
+Defaults to null.
 
 
 ### factorio.rcon_port
 
-TCP port to start the RCON interface on the Factorio server on.  If null
-a random port in the dynamic range is assigned each time the instance
-starts.
+TCP port to start the RCON interface on the Factorio server on.
+If null a random port in the dynamic range is assigned each time the instance starts.
 
-Defaults to null
+Defaults to null.
 
 
 ### factorio.rcon_password
 
-Password to use for the RCON interafec.  If null a random secure
-password is generated and used each time the instance starts.
+Password to use for the RCON interafec.
+If null a random secure password is generated and used each time the instance starts.
 
-Defaults to null
+Defaults to null.
 
 
 ### factorio.enable_save_patching
 
-Whether to use save patching or not.  When enabled lua code is patched
-into the game save before starting it.  Most plugins require the use of
-save patching to function.  Turning it off makes it possible to use
-Clusterio to run and manage regular vanilla games and scenarios not
-compatible with Clusterio.
+Whether to use save patching or not.
+When enabled lua code is patched into the game save before starting it.
+Most plugins require the use of save patching to function.
+Turning it off makes it possible to use Clusterio to run and manage regular vanilla games and scenarios not compatible with Clusterio.
 
-Defaults to true
+Defaults to true.
 
 
 ### factorio.enable_whitelist
 
 Turn on the whitelist on the server.
 
-Defaults to false
+Defaults to false.
 
 
 ### factorio.settings
 
-Object with the settings to put into `server-settings.json` for the
-Factorio server.  The settings in `data/server-settings.example.json` of
-the Factorio installation is used as the base and properties specified
-here overrides the properties there.
+Object with the settings to put into `server-settings.json` for the Factorio server.
+The settings in `data/server-settings.example.json` of the Factorio installation is used as the base and properties specified here overrides the properties there.
 
-Changes to the following properties will be applied live if the instance
-is running while it is changed: `afk_autokick_interval`,
-`allow_commands`, `autosave_interval`, `autosave_only_on_server`,
-`description`, `ignore_player_limit_for_returning_players`,
-`max_players`, `max_upload_slots`, `max_upload_in_kilobytes_per_second`,
-`name`, `only_admins_can_pause_the_game`, `game_password`,
-`require_user_verification`, `tags`, `visibility`.
+Changes to the following properties will be applied live if the instance is running while it is changed: `afk_autokick_interval`, `allow_commands`, `autosave_interval`, `autosave_only_on_server`, `description`, `ignore_player_limit_for_returning_players`, `max_players`, `max_upload_slots`, `max_upload_in_kilobytes_per_second`, `name`, `only_admins_can_pause_the_game`, `game_password`, `require_user_verification`, `tags`, `visibility`.
 
 Defaults to {"tags":["clusterio"],"auto_pause":false}.
 
 
 ### factorio.verbose_logging
 
-Pass the `--verbose` flag to Factorio when starting the server.  This
-prints more messages to the log.
+Pass the `--verbose` flag to Factorio when starting the server.
+This prints more messages to the log.
 
-Defaults to false
+Defaults to false.
 
 
 ### factorio.strip_paths
 
-Strip down absolute paths in the server log going to files inside the
-instance directory such that they are relative to the instance
-directory.  This improves the signal to noise ratio of the log.
+Strip down absolute paths in the server log going to files inside the instance directory such that they are relative to the instance directory.
+This improves the signal to noise ratio of the log.
 
 Sample output when disabled:
 
@@ -356,86 +314,59 @@ Sample output when enabled:
     0.614 Checksum for script temp/currently-playing/control.lua: 2390553941
     1.277 Script @modules/example/test.lua:7: Example log line.
 
-Defaults to true
+Defaults to true.
 
 ### factorio.sync_adminlist
 
-Synchronize in-game admin list with admin status of the users in
-cluster.  If enabled Clusterio will generate a new
-`server-adminlist.json` on instance startup based on the users in the
-cluster with admin status set to true, and keep the admins in sync with
-the users that have admin status while the instance is running.
+Synchronize in-game admin list with admin status of the users in cluster.
+If enabled Clusterio will generate a new `server-adminlist.json` on instance startup based on the users in the cluster with admin status set to true, and keep the admins in sync with the users that have admin status while the instance is running.
 
-Defaults to true
+Defaults to true.
 
 
 ### factorio.sync_whitelist
 
-Synchronize in-game whitelist with the whitelisted status of the users
-in the cluster.  If enabled Clusterio will generate a new
-`server-whitelist.json` on instance startup based on the users in the
-cluster with whitelisted status set to true, and keep the whitelisted
-users in sync with the users that have whitelisted status while the
-instance in running.
+Synchronize in-game whitelist with the whitelisted status of the users in the cluster.
+If enabled Clusterio will generate a new `server-whitelist.json` on instance startup based on the users in the cluster with whitelisted status set to true, and keep the whitelisted users in sync with the users that have whitelisted status while the instance in running.
 
-Defaults to true
+Defaults to true.
 
 
 ### factorio.sync_banlist
 
-Synchronize in-game banlist with the banned status of users in the
-cluster.  If enabled Clusterio will generate a new `server-banlist.json`
-on instance startup based on users in the cluster with banned status set
-to true, and keep the banned users in sync with the users that have the
-banned status while the instance is running.
+Synchronize in-game banlist with the banned status of users in the cluster.
+If enabled Clusterio will generate a new `server-banlist.json` on instance startup based on users in the cluster with banned status set to true, and keep the banned users in sync with the users that have the banned status while the instance is running.
 
-Defaults to true
+Defaults to true.
 
 
 ### factorio.max_concurrent_commands
 
 Maximum number of commands being transmitted into the game in parallel.
-Since the rate at which long commands are streamed into the game is by
-default limeted to 100 bytes/tick and scales down to 25 bytes/tick when
-there's 20 players connected, long commands can hold up the command
-interface and cause large latencies in getting data pushed into the
-game. (The rates are controlled by the `segment_size` options in the
-server settings.)  To counteract this Clusterio sends up to this
-configured value number of commands in parallel over the RCON interface.
-This causes the game updates sent to clients to have this many command
-streams in parallel contained in them, drastically increasing the
-maxiumum size they can become.  Since commands are only processed so
-ofter the maximum rate of commands that can be sustained is roughly 30
-times this configured value per second, though note that large commands
-will lower this value.
+Since the rate at which long commands are streamed into the game is by default limeted to 100 bytes/tick and scales down to 25 bytes/tick when there's 20 players connected, long commands can hold up the command interface and cause large latencies in getting data pushed into the game.
+(The rates are controlled by the `segment_size` options in the server settings.)
+To counteract this Clusterio sends up to this configured value number of commands in parallel over the RCON interface.
+This causes the game updates sent to clients to have this many command streams in parallel contained in them, drastically increasing the maxiumum size they can become.
+Since commands are only processed so ofter the maximum rate of commands that can be sustained is roughly 30 times this configured value per second, though note that large commands will lower this value.
 
-The game updates sent by the server is split into roughly 500 byte
-packets, and if any one of those parts are lost the entire update is
-resent.  This means a high number of concurrent commands can amplify
-resends due to packet loss and degrade the player experience up to the
-point of becomming completely unplayable.
+The game updates sent by the server is split into roughly 500 byte packets, and if any one of those parts are lost the entire update is resent.
+This means a high number of concurrent commands can amplify resends due to packet loss and degrade the player experience up to the point of becomming completely unplayable.
 
-Prior to 0.18.7 the maximum practical size of game update sent where
-arround 8 kB due to the UDP receive buffer on windows defaulting to this
-value, larger updates would not get through the receive buffer and cause
-the connection to drop.  To stay below the 8 kB limit the maximum safe
-value for this option would be around 7000 / (3 * game_speed *
-maximum_segment_size), which is around 20 in normal circumstances.
+Prior to 0.18.7 the maximum practical size of game update sent where arround 8 kB due to the UDP receive buffer on windows defaulting to this value, larger updates would not get through the receive buffer and cause the connection to drop.
+To stay below the 8 kB limit the maximum safe value for this option would be around 7000 / (3 * game_speed * maximum_segment_size), which is around 20 in normal circumstances.
 
-Defaults to 5
+Defaults to 5.
 
 
 ### <plugin_name>.load_plugin
 
-Whether to load the given plugin on the instance.  Note that plugins
-need to be loaded on the master server in order for them to be loaded on
-instances.
+Whether to load the given plugin on the instance.
+Note that plugins need to be loaded on the master server in order for them to be loaded on instances.
 
-Defaults to true
+Defaults to true.
 
 
-Control Configuration
----------------------
+## Control Configuration
 
 ### control.master_url
 
@@ -446,30 +377,22 @@ Defaults to null meaning complain about it not being set and exit.
 
 ### control.master_token
 
-Access token used for authenticating with the master server.  You can
-generate an access token with `clusteriomaster bootstrap
-generate-user-token <username>`, or use the `clusteriomaster bootstrap
-create-ctl-config <username>` to create a new ctl config with the
-correct url and token in it.
+Access token used for authenticating with the master server.
+You can generate an access token with `clusteriomaster bootstrap generate-user-token <username>`, or use the `clusteriomaster bootstrap create-ctl-config <username>` to create a new ctl config with the correct url and token in it.
 
 Defaults to null meaning complain about it not being set and exit.
 
 
 ### control.tls_ca
 
-Path to certificate in PEM format to use for validating a TLS connection
-to the master server.  If you have a self signed certificate on the
-master server you will need to copy the certificate to the computer you
-run clusterctl from and set it as the certificate authority with this
-option.
+Path to certificate in PEM format to use for validating a TLS connection to the master server.
+If you have a self signed certificate on the master server you will need to copy the certificate to the computer you run clusterctl from and set it as the certificate authority with this option.
 
-Defaults to null meaning use Node.js's default set of trusted
-certificate authorities.
+Defaults to null meaning use Node.js's default set of trusted certificate authorities.
 
 
 ### control.reconnect_delay
 
-Duration in seconds to wait before attempting to reconnect with the
-master server after the connection is dropped.
+Duration in seconds to wait before attempting to reconnect with the master server after the connection is dropped.
 
 Defaults to 2.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,13 +1,11 @@
-Contributing to Clusterio
-=========================
+# Contributing to Clusterio
 
-You are probably reading this because you want to contribute code to
-Clusterio.  Great!  We need people like you.  Though we have some
-conventions and workflows that we kindly ask you to follow.
+You are probably reading this because you want to contribute code to Clusterio.
+Great!  We need people like you.
+Though we have some conventions and workflows that we kindly ask you to follow.
 
 
-Contents
---------
+## Contents
 
 - [Workflow](#workflow)
     - [Starting a Feature Branch](#starting-a-feature-branch)
@@ -23,205 +21,160 @@ Contents
     - [Naming Style](#naming-style)
     - [Indenting](#indenting)
     - [Line Length](#line-length)
+    - [Markdown](#markdown)
 
 
-Workflow
---------
+## Workflow
 
-While we don't require you to follow this workflow, it makes things much
-simpler for both you and us if you choose to do so.  Especially when it
-comes to making the commit history reflect what happened and not be a
-giant ball of mess.  GitHub's git workflow is less than ideal for
-dealing with small feature-branches so you might see things being done
-here a little diffrent than the usual.
+While we don't require you to follow this workflow, it makes things much simpler for both you and us if you choose to do so.
+Especially when it comes to making the commit history reflect what happened and not be a giant ball of mess.
+GitHub's git workflow is less than ideal for dealing with small feature-branches so you might see things being done here a little diffrent than the usual.
 
-It is recommended that you use the command line git version for doing
-the operations described here.  GUI wrappers tend to have different
-ideas of what is what and you might find it difficult to make it do the
-things described here.  For doing the actual commits though, your
-faviorit git GUI should work just fine.
+It is recommended that you use the command line git version for doing the operations described here.
+GUI wrappers tend to have different ideas of what is what and you might find it difficult to make it do the things described here.
+For doing the actual commits though, your faviorit git GUI should work just fine.
 
-If you pressed the fork button on GitHub and used `git clone` _on your
-own fork_ you can skip to the next paragraph.  Otherwise you will have
-to click the fork button and clone your fork.  If you already cloned the
-main GitHub repository you can change your clone to point at your own
-fork using the `git remote` command, but it's probably easier to delete
-your local clone and clone it again.
+If you pressed the fork button on GitHub and used `git clone` _on your own fork_ you can skip to the next paragraph.
+Otherwise you will have to click the fork button and clone your fork.
+If you already cloned the main GitHub repository you can change your clone to point at your own fork using the `git remote` command, but it's probably easier to delete your local clone and clone it again.
 
-To keep your local repository up to to date with the main repository add
-the main repository as a remote.
+To keep your local repository up to to date with the main repository add the main repository as a remote.
 
     git remote add upstream https://github.com/clusterio/factorioClusterio
 
-After this running `git fetch upstream` will get the updated branches
-from the main repository.  Do not run `git pull upstream` it will mess
-thing up!
+After this running `git fetch upstream` will get the updated branches from the main repository.
+Do not run `git pull upstream` it will mess thing up!
 
 
 ### Setting up the Development Environment
 
-The project is organized into several packages that are all managed
-through Lerna.  In order to get the development environment up and
-running you will need to run the following commands:
+The project is organized into several packages that are all managed through Lerna.
+In order to get the development environment up and running you will need to run the following commands:
 
     npm install
     npx lerna bootstrap
 
-This installs dependencies needed by tests and links the packages up so
-they work from the git work tree.
+This installs dependencies needed by tests and links the packages up so they work from the git work tree.
 
 
 ### Starting a Feature Branch
 
-Development is done exclusively in feature branches.  This means the
-first thing to do before starting any development at all is to make a
-new branch starting from the master or 1.2.x branch of the main
-repository.  To do this check out that branch from the main repository
-(substitute master for 1.2.x if you're working on that branch.)
+Development is done exclusively in feature branches.
+This means the first thing to do before starting any development at all is to make a new branch starting from the master or 1.2.x branch of the main repository.
+To do this check out that branch from the main repository (substitute master for 1.2.x if you're working on that branch).
 
     git fetch upstream
     git checkout upstream/master
 
-This will give a warning about detached HEAD which means you did it
-correctly.  Now you can make a feature branch based on this with.
+This will give a warning about detached HEAD which means you did it correctly.
+Now you can make a feature branch based on this with.
 
     git checkout -b my-feature-branch
 
-The name of the branch is not important, as long as it's not a name
-you've used before.  But it's nice to have its name be somewhat
-descriptive of what it implements.
+The name of the branch is not important, as long as it's not a name you've used before.
+But it's nice to have its name be somewhat descriptive of what it implements.
 
 
 ### Checking your code for errors
 
-There's automated tests and linting setup for the project.  Please do
-add tests for any code you add and run both:
+There's automated tests and linting setup for the project.
+Please do add tests for any code you add and run both:
 
     npm run test
     npm run lint
 
-To check that your changes pass the integration tests as well as the
-ESLint rules set up for the project.
+To check that your changes pass the integration tests as well as the ESLint rules set up for the project.
 
 
 ### Submitting a Pull Request
 
-Once you've commited changes to your feature branch that you want to
-have included into the main repository push it to you fork with
+Once you've commited changes to your feature branch that you want to have included into the main repository push it to you fork with
 
     git push origin my-feature-branch
 
-and make a pull request through the GitHub web interface.  You can also
-pass the `--set-upstream` (or `-u`) flag to make `git push` do the same
-thing for this branch.  After your feature branch have been merged you
-should consider it final.  If there are more changes you want to have
-merged or mistakes you need to fix you must start a new feature branch
-and submit a new pull request
+and make a pull request through the GitHub web interface.
+You can also pass the `--set-upstream` (or `-u`) flag to make `git push` do the same thing for this branch.
+After your feature branch have been merged you should consider it final.
+If there are more changes you want to have merged or mistakes you need to fix you must start a new feature branch and submit a new pull request.
 
 
 ### Editing your Feature Branch
 
-Until your feature branch is merged you can edit it as you see fit by
-using the rebase tool.  If your feature branch has been merged however
-it's final and you will have to start a new feature branch and submit
-that in a new pull request.  The base usage of rebase assuming you are
-checked out on your feature branch is the following command (substitute
-master with 1.2.x if your feature branch is based on that)
+Until your feature branch is merged you can edit it as you see fit by using the rebase tool.
+If your feature branch has been merged however it's final and you will have to start a new feature branch and submit that in a new pull request.
+The base usage of rebase assuming you are checked out on your feature branch is the following command (substitute master with 1.2.x if your feature branch is based on that)
 
     git rebase -i upstream/master
 
-This will open up an editor with the commits of your feature branch and
-let you reorder, edit, and remove commits as you see fit.
+This will open up an editor with the commits of your feature branch and let you reorder, edit, and remove commits as you see fit.
 
-If the main repository has been updated and you have fetched down those
-updates with `git fetch upstream` this will also move your feature
-branch so that it is based on the latest commit from the main
-repository.
+If the main repository has been updated and you have fetched down those updates with `git fetch upstream` this will also move your feature branch so that it is based on the latest commit from the main repository.
 
-If you have already pushed your feature branch to your fork a simple
-`git push origin my-feature-branch` will no longer work as the histories
-are different, instead you will have to run
+If you have already pushed your feature branch to your fork a simple `git push origin my-feature-branch` will no longer work as the histories are different, instead you will have to run
 
     git push origin +my-feature-branch
 
-The + sign signifies a force push and should be used with care.  If you
-have a pull request that has not yet been merged submitted for this
-feature branch this will update the pull request too.
+The + sign signifies a force push and should be used with care.
+If you have a pull request that has not yet been merged submitted for this feature branch this will update the pull request too.
 
 
 ### Resolving Merge Conflicts
 
-The best way to resolve merge conflicts in feature braches is to rebase
-it on top of the updated upstream.  Run the following commands
-(substitute master with 1.2.x if your feature branch is based on that)
+The best way to resolve merge conflicts in feature braches is to rebase it on top of the updated upstream.
+Run the following commands (substitute master with 1.2.x if your feature branch is based on that)
 
     git fetch upstream
     git rebase upstream/master
 
-This will stop on the commit(s) that caused the merge conflict and let
-you resolve them manually before continuing.  Once you're done force
-push your updated feature branch with
+This will stop on the commit(s) that caused the merge conflict and let you resolve them manually before continuing.
+Once you're done force push your updated feature branch with
 
     git push origin +my-feature-branch
 
 
 ### Updating Your GitHub Fork
 
-No.  This is pointless busywork that accomplishes nothing.  Fetch the
-main repository directly as described above and base your feature
-branches on the refs from it.  GitHub has no interface or functionality
-for keeping the branches in your fork up to date with the branches in
-the main repository and there is no point in doing this for our feature
-branch based workflow.
+No.
+This is pointless busywork that accomplishes nothing.
+Fetch the main repository directly as described above and base your feature branches on the refs from it.
+GitHub has no interface or functionality for keeping the branches in your fork up to date with the branches in the main repository and there is no point in doing this for our feature branch based workflow.
 
 
-Changelog
----------
+## Changelog
 
-There's a [Changelog](../CHANGELOG.md) in the root of the project.  If
-you make changes that are visible to users of this project you should
-add an entry to the changelog describing what has changed.  The format
-of this log should be self explanatory, please follow it carefully.
+There's a [Changelog](../CHANGELOG.md) in the root of the project.
+If you make changes that are visible to users of this project you should add an entry to the changelog describing what has changed.
+The format of this log should be self explanatory, please follow it carefully.
 
 
-Supported Node.js and Factorio Versions
----------------------------------------
+## Supported Node.js and Factorio Versions
 
-Clusterio run on Node.js v12 and up, and v10 from v10.16.0, make sure
-to check that the Node builtin API's and npm packages you use are
-supported on these versions.  The Travis CI tests are runned on whatever
-version of Node.js v10 is the default, which at the time of writing is
-v10.18.0.
+Clusterio run on Node.js v12 and up, and v10 from v10.16.0, make sure to check that the Node builtin API's and npm packages you use are supported on these versions.
+The Travis CI tests are runned on whatever version of Node.js v10 is the default, which at the time of writing is v10.18.0.
 
-For Factorio Clusterio 2.0 aims to support version 0.17.69 and up,
-including the latest experimental release.  It's recommended that you
-use the lua API reference for 0.17.69, as there's no information on what
-version Factorio API's were introduced in.  The Travis CI tests are
-runned against latest experimental release.
+For Factorio Clusterio 2.0 aims to support version 0.17.69 and up, including the latest experimental release.
+It's recommended that you use the lua API reference for 0.17.69, as there's no information on what version Factorio API's were introduced in.
+The Travis CI tests are runned against latest experimental release.
 
 
-Code Style
-----------
+## Code Style
 
-The style of the code is a bit of a mixed bag at the moment.  But there
-are at least a few things that have been agreed upon.
+The style of the code is a bit of a mixed bag at the moment.
+But there are at least a few things that have been agreed upon.
 
 
 ### Naming style
 
-JavaScript variables in general uses camelCase.  The exception is for
-classes/constructors which use PascalCase and variables destructured
-from over the wire objects.
+JavaScript variables in general uses camelCase.
+The exception is for classes/constructors which use PascalCase and variables destructured from over the wire objects.
 
-Fields in configs and messages sent over links uses
-lowercase_underscore.
+Fields in configs and messages sent over links uses lowercase_underscore.
 
-JavaScript files are named using lowercase_underscore for files that
-export multiple items.  Files containing and exporting a single class
-should be named the same as the class in PascalCase.
+JavaScript files are named using lowercase_underscore for files that export multiple items.
+Files containing and exporting a single class should be named the same as the class in PascalCase.
 
-Imported modules from the lib package are prefixed with lib to make them
-easier to distinguish, as the names tend to be very generic.  E.g.:
+Imported modules from the lib package are prefixed with lib to make them easier to distinguish, as the names tend to be very generic.
+E.g.:
 
     const libLink = require("@clusterio/lib/link");
     const libLuaTools = require("@clusterio/lib/lua_tools");
@@ -232,9 +185,7 @@ For lua code lowercase_underscore is used for everything.
 
 ### Strings
 
-JavaScript and Lua code should use double quoted strings (`"string"`)
-for all strings with the only exception that strings that contain double
-quotes may use single quotes (i.e., `'String with "quotes"'`).
+JavaScript and Lua code should use double quoted strings (`"string"`) for all strings with the only exception that strings that contain double quotes may use single quotes (i.e., `'String with "quotes"'`).
 JavaScript template literals may also be used where appropriate.
 
 
@@ -248,8 +199,8 @@ Lua code should be indented with 4 spaces.
 ### Line Length
 
 Lines are limited to 120 characters where tabs count as 4 characters.
-If the argument list for a function or expressino for compound statement
-gets very long break them out on their own line(s).  For example:
+If the argument list for a function or expressino for compound statement gets very long break them out on their own line(s).
+For example:
 
     function foo(
         really, long, argument, list,
@@ -262,3 +213,25 @@ gets very long break them out on their own line(s).  For example:
             // code
         }
     })
+
+
+### Markdown
+
+Markdown files are formatted using one line per sentence to improve diff reports when making changes.
+Headings have two spaces before them and on space after them to make them stand out, the heading at the top of the file does not have any spaces before it, and heading immediadly followed by another heading have one space between them.
+For example:
+
+```md
+# A markdown File
+
+Sentence of text which end in a period.
+Each sentence is on it's own line.
+And there's two spaces before the next heading.
+
+
+## Subheading
+
+### Sub-subheading
+
+Headings use the `# heading` format.
+```

--- a/docs/developing-for-clusterio.md
+++ b/docs/developing-for-clusterio.md
@@ -1,13 +1,9 @@
-Developing for Clusterio
-========================
+# Developing for Clusterio
 
-This document describes the various different types of content that can
-be created for Factorio and/or Clusterio and how this is made compatible
-with Clusterio.
+This document describes the various different types of content that can be created for Factorio and/or Clusterio and how this is made compatible with Clusterio.
 
 
-Contents
---------
+## Contents
 
 - [Factorio Mods](#factorio-mods)
 - [Factorio Scenarios](#factorio-scenarios)
@@ -18,35 +14,21 @@ Contents
 - [Clusterio Plugins](#clusterio-plugins)
 
 
-Factorio Mods
--------------
+## Factorio Mods
 
-Factorio mods that do not interact with Clusterio should not have any
-considerations that need to be taken into account for them to work with
-Clusterio.
+Factorio mods that do not interact with Clusterio should not have any considerations that need to be taken into account for them to work with Clusterio.
 
 
-Factorio Scenarios
-------------------
+## Factorio Scenarios
 
-Clusterio patches saves and because of this scenarios have a few
-limitations and must explicitly mark themselves as compatible with
-Clusterio to work.  The main limitation is that the
-[event_handler](https://github.com/wube/factorio-data/blob/master/core/lualib/event_handler.lua)
-lib must be used, and control.lua cannot contain any code other than
-calls to event_handler loading the relevant libs of the scenario.
-This is because the control.lua file will be overwritten by the save
-patcher.  Scenarios also cannot use the event registering functions
-exposed by `script` such as `script.on_event` or `script.on_nth_tick` as
-using these will overwrite the handlers registered by the
-event_handler lib.
+Clusterio patches saves and because of this scenarios have a few limitations and must explicitly mark themselves as compatible with Clusterio to work.
+The main limitation is that the [event_handler](https://github.com/wube/factorio-data/blob/master/core/lualib/event_handler.lua) lib must be used, and control.lua cannot contain any code other than calls to event_handler loading the relevant libs of the scenario.
+This is because the control.lua file will be overwritten by the save patcher.
+Scenarios also cannot use the event registering functions exposed by `script` such as `script.on_event` or `script.on_nth_tick` as using these will overwrite the handlers registered by the event_handler lib.
 
-A brief description of the usage of the event_handler library is
-provided in the [event_handler interface](#event_handler-interface)
-section.
+A brief description of the usage of the event_handler library is provided in the [event_handler interface](#event_handler-interface) section.
 
-Once a scenario is made using the event_handler it should have a
-control.lua file that looks something like this:
+Once a scenario is made using the event_handler it should have a control.lua file that looks something like this:
 
 ```lua
 -- control.lua
@@ -55,8 +37,7 @@ event_handler.add_lib(require("module_foo"))
 event_handler.add_lib(require("module_bar"))
 ```
 
-To make Clusterio recognize and correctly handle this scenario it
-needs to include a clusterio.json file with following content:
+To make Clusterio recognize and correctly handle this scenario it needs to include a clusterio.json file with following content:
 
 ```json
 {
@@ -70,60 +51,43 @@ needs to include a clusterio.json file with following content:
 }
 ```
 
-This tells Clusterio that it should load both module_foo and module_bar
-by passing the result of requiring them to the  `add_lib` function when
-writing a new control.lua file to the save.
+This tells Clusterio that it should load both module_foo and module_bar by passing the result of requiring them to the `add_lib` function when writing a new control.lua file to the save.
 
 
 ### event_handler interface
 
-<sub>**Note:** At the time of writing the event_handler lib has been
-a part of Factorio since at least 0.17.4, and was moved from base to
-core in 0.17.63 but is still not documented anywhere.  A brief
-description is provided here for this reason.</sub>
+<sub>**Note:** At the time of writing the event_handler lib has been a part of Factorio since at least 0.17.4, and was moved from base to core in 0.17.63 but is still not documented anywhere.
+A brief description is provided here for this reason.</sub>
 
-The event_handler lib provides a simple interface for registering
-multiple callbacks to the same events without having to be concerned
-with callback chaining or overwriting callbacks defined elsewhere.  It
-works by taking over the task of registering the actual callbacks with
-Factorio, providing its own interface for the rest of the code to use.
+The event_handler lib provides a simple interface for registering multiple callbacks to the same events without having to be concerned with callback chaining or overwriting callbacks defined elsewhere.
+It works by taking over the task of registering the actual callbacks with Factorio, providing its own interface for the rest of the code to use.
 
-The sole function of interest exported by event_handler is `add_lib`
-which accepts a table with event handler callbacks definitions that it
-will register.  The following entries are recognized by `add_lib`, all
-of which are optional:
+The sole function of interest exported by event_handler is `add_lib` which accepts a table with event handler callbacks definitions that it will register.
+The following entries are recognized by `add_lib`, all of which are optional:
 
 - `on_init`:
     Callback called when the callback of `script.on_init` is invoked.
 - `on_load`:
     Callback called when the callback of `script.on_load` is invoked.
 - `on_configuration_changed`:
-    Callback called when the callback of
-    `script.on_configuration_changed` is invoked.
+    Callback called when the callback of `script.on_configuration_changed` is invoked.
 - `events`:
     Table mapping event ids as defined in `defines.events` to callbacks.
-    For example the table `{ [defines.events.on_player_died] = foo }`
-    will call bar with the usual `event` table as argument every time a
-    player dies.
+    For example the table `{ [defines.events.on_player_died] = foo }` will call bar with the usual `event` table as argument every time a player dies.
 - `on_nth_tick`:
-    Table mapping the nth tick number to a callback.  For example the
-    table `{ [30] = bar }` will call bar every 30th tick.
+    Table mapping the nth tick number to a callback.
+    For example the table `{ [30] = bar }` will call bar every 30th tick.
 - `add_remote_interface`:
-    Callback called before on_init/on_load callbacks<sup>[1]</sup>.  It
-    has no special meaning and receives no arguments but should be used
-    for registering remote interfaces.
+    Callback called before on_init/on_load callbacks<sup>[1]</sup>.
+    It has no special meaning and receives no arguments but should be used for registering remote interfaces.
 - `add_commands`:
-    Callback called before on_init/on_load callbacks<sup>[1]</sup>.  It
-    has no special meaning and receives no arguments but should be used
-    for registering commands.
+    Callback called before on_init/on_load callbacks<sup>[1]</sup>.
+    It has no special meaning and receives no arguments but should be used for registering commands.
 
-<sub>1: Before 0.17.69 these callbacks were called after
-on_init/on_load.</sub>
+<sub>1: Before 0.17.69 these callbacks were called after on_init/on_load.</sub>
 
-The usual way to use `add_lib` is to define the table of events to
-register in a separate file and return it, then load it in control.lua
-via `require` before passing it to `add_lib`.  For example a module
-could be defined as
+The usual way to use `add_lib` is to define the table of events to register in a separate file and return it, then load it in control.lua via `require` before passing it to `add_lib`.
+For example a module could be defined as
 
 ```lua
 -- example.lua
@@ -148,45 +112,27 @@ local event_handler = require("event_handler")
 event_handler.add_lib(require("example"))
 ```
 
-Because the event_handler lib registers events itself you may not use
-`script.on_load` or `script.on_init` at all in your code and any usage
-of `script.on_configuration_changed`, `script.on_nth_tick` and/or
-`script.on_event` will cause the corresponding events registered with
-event_handler to break and should therefore not be used.
+Because the event_handler lib registers events itself you may not use `script.on_load` or `script.on_init` at all in your code and any usage of `script.on_configuration_changed`, `script.on_nth_tick` and/or `script.on_event` will cause the corresponding events registered with event_handler to break and should therefore not be used.
 
-There's also the `add_libraries` function exported by event_handler,
-which accepts a table and calls `add_lib` for each value in the table.
+There's also the `add_libraries` function exported by event_handler, which accepts a table and calls `add_lib` for each value in the table.
 
 
-Communicating with Clusterio
-----------------------------
+## Communicating with Clusterio
 
-Clusterio uses a homebrew protocol based on sending JSON payloads over
-a WebSocket connection.  See [socket.md](socket.md) for the
-implementation details of it.
+Clusterio uses a homebrew protocol based on sending JSON payloads over a WebSocket connection.
+See [socket.md](socket.md) for the implementation details of it.
 
-It's also possible to write a plugin for Clusterio that exposes a custom
-interface over HTTP, WebSocket or any other technology supported by
-Node.js.
+It's also possible to write a plugin for Clusterio that exposes a custom interface over HTTP, WebSocket or any other technology supported by Node.js.
 
 
-Clusterio Modules
------------------
+## Clusterio Modules
 
-Modules are primarily used by plugins to inject code into Factorio games
-with the save patcher, though it's also possible to make stand alone
-modules that are loaded into the game if you don't need the capabilites
-of the plugin system.  The save patcher puts modules into the `modules`
-folder of the Factorio save and adds code to `control.lua` to load the
-module according to the `load` and `require` options to the module.json
-file.  Like with scenarios for Clusterio the [event_handler
-interface](#event_handler-interface) has to be used for any event
-subscriptions in modules.
+Modules are primarily used by plugins to inject code into Factorio games with the save patcher, though it's also possible to make stand alone modules that are loaded into the game if you don't need the capabilites of the plugin system.
+The save patcher puts modules into the `modules` folder of the Factorio save and adds code to `control.lua` to load the module according to the `load` and `require` options to the module.json file.
+Like with scenarios for Clusterio the [event_handler interface](#event_handler-interface) has to be used for any event subscriptions in modules.
 
-Stand alone modules are placed into the modules folder of Clusterio,
-plugin modules are located in the module folder of the plugin.  In
-either case a `module.json` file is required and has the following
-structure:
+Stand alone modules are placed into the modules folder of Clusterio, plugin modules are located in the module folder of the plugin.
+In either case a `module.json` file is required and has the following structure:
 
 ```json
 {
@@ -204,68 +150,44 @@ structure:
 The following entries are supported in the module.json file:
 
 - `name`:
-    Name of the module, must match the folder the module is located in
-    for stand alone modules or the name of the plugin the module is
-    located in.
+    Name of the module, must match the folder the module is located in for stand alone modules or the name of the plugin the module is located in.
 - `version`:
-    Version of the module.  Must be compatible with [Semantic Versioning
-    2.0.0](https://semver.org/).  In plugin modules this defaults to the
-    version of the plugin otherwise it's required.
+    Version of the module.
+    Must be compatible with [Semantic Versioning 2.0.0](https://semver.org/).
+    In plugin modules this defaults to the version of the plugin otherwise it's required.
 - `dependencies`:
-    Optional mapping of modules this module depends on and their
-    version.  In the example `>=0.4.2` means that the foo module must be
-    at least version 0.4.2.  See the [Ranges
-    syntax](https://www.npmjs.com/package/semver#ranges) of the
-    node-semver package for a full description of what operators are
-    supported.  The events for dependencies is invoked before the events
-    of the dependent, and starting an instance will fail if the
-    dependencies cannot be satisfied.  If not specified it will default
-    to depending on `clusterio`.  Make sure to add `clusterio` to your
-    dependencies if you add other dependencies and depend on the Lua API.
+    Optional mapping of modules this module depends on and their version.
+    In the example `>=0.4.2` means that the foo module must be at least version 0.4.2.
+    See the [Ranges syntax](https://www.npmjs.com/package/semver#ranges) of the node-semver package for a full description of what operators are supported.
+    The events for dependencies is invoked before the events of the dependent, and starting an instance will fail if the dependencies cannot be satisfied.
+    If not specified it will default to depending on `clusterio`.
+    Make sure to add `clusterio` to your dependencies if you add other dependencies and depend on the Lua API.
 - `require`:
-    Lua files to require in `control.lua`.  This should only really be
-    needed if you want to make a global function available for use in
-    Lua commands.  The paths are relative to the module's own folder and
-    should be specified using forward slashes as directory sepparators
-    if it's located in a sub directory in the module.
+    Lua files to require in `control.lua`.
+    This should only really be needed if you want to make a global function available for use in Lua commands.
+    The paths are relative to the module's own folder and should be specified using forward slashes as directory sepparators if it's located in a sub directory in the module.
 - `load`:
-    Lua files to load with the `event_handler` lib, the result of
-    requiring the file will be passed to the `add_lib` function of the
-    `event_handler` lib in `control.lua`.  See the section on the
-    [event_handler interface](#event_handler-interface) for a detailed
-    description on how the `event_handler` lib works.  The paths are
-    relative to the module's own folder and should be specified using
-    forward slashes as directory sepparators if it's located in a sub
-    directory in the module.
+    Lua files to load with the `event_handler` lib, the result of requiring the file will be passed to the `add_lib` function of the `event_handler` lib in `control.lua`.
+    See the section on the [event_handler interface](#event_handler-interface) for a detailed description on how the `event_handler` lib works.
+    The paths are relative to the module's own folder and should be specified using forward slashes as directory sepparators if it's located in a sub directory in the module.
 
-It's recommended to use the new style of defining modules in Lua, as
-well as avoid the use of global variables as much as possible.  This
-means always declearing your top level variables and functions local and
-exporting only the things you need in other files.  You can require
-other files in your module by prefixing your require paths with
-`modules/your_module_name/`.  It's also possible to require files from
-other modules this way too.
+It's recommended to use the new style of defining modules in Lua, as well as avoid the use of global variables as much as possible.
+This means always declearing your top level variables and functions local and exporting only the things you need in other files.
+You can require other files in your module by prefixing your require paths with `modules/your_module_name/`.
+It's also possible to require files from other modules this way too.
 
-The global variables and data stored in the global table is shared by
-all Clusterio modules as well as the scenario, so it's important that
-you use unique names.  It's recommended to prefix the global variables
-and data in the global table that your module has with the name of your
-module.
+The global variables and data stored in the global table is shared by all Clusterio modules as well as the scenario, so it's important that you use unique names.
+It's recommended to prefix the global variables and data in the global table that your module has with the name of your module.
 
-Because modules can be patched into an existing game you cannot rely on
-the `on_init` callback to be called in Clusterio Modules.  Nor can you
-rely on the `on_configuration_changed` callback, as this is not called
-when level code changes.  The Clusterio Lua API provides the custom
-`on_server_startup` event that can be used as a substitute, see the next
-section.
+Because modules can be patched into an existing game you cannot rely on the `on_init` callback to be called in Clusterio Modules.
+Nor can you rely on the `on_configuration_changed` callback, as this is not called when level code changes.
+The Clusterio Lua API provides the custom `on_server_startup` event that can be used as a substitute, see the next section.
 
 
-Clusterio Lua API
------------------
+## Clusterio Lua API
 
-Clusterio provides a save patched module as well as a regular Factorio
-mod for interfacing with Clusterio.  This includes tools sending data to
-plugins, script events to listen for, and an item serialization module.
+Clusterio provides a save patched module as well as a regular Factorio mod for interfacing with Clusterio.
+This includes tools sending data to plugins, script events to listen for, and an item serialization module.
 
 
 ### clusterio_api library
@@ -276,30 +198,27 @@ From a module
 From a mod  
 `local clusterio_api = require("__clusterio_lib__/api")`
 
-Provides the main interface to Clusterio from within the game.  When
-using the mod version you must call `init` before it'll function
-properly.
+Provides the main interface to Clusterio from within the game.
+When using the mod version you must call `init` before it'll function properly.
 
 #### init
 
 <sub>Mod version only</sub>
 
-Initialize the API.  This should be called from both the `on_init` and
-`on_load` events in your mod, and before this is called certain features
-will not be available, most notably the events table.
+Initialize the API.
+This should be called from both the `on_init` and `on_load` events in your mod, and before this is called certain features will not be available, most notably the events table.
 
 #### clusterio_api.events
 
-Table of events raised by clusterio.  If the game is started outside of
-Clusterio then none of these events will be raised.
+Table of events raised by clusterio.
+If the game is started outside of Clusterio then none of these events will be raised.
 
-In the mod version this table does not exist before the `init` function
-is called.
+In the mod version this table does not exist before the `init` function is called.
 
 ##### on_instance_updated
 
-Raised after the name and id of an instance has been updated.  This may
-occur even if the id and name didn't change.
+Raised after the name and id of an instance has been updated.
+This may occur even if the id and name didn't change.
 
 Event data:
 - `instance_id`: the id of the instance.
@@ -307,33 +226,26 @@ Event data:
 
 ##### on_server_startup
 
-Raised when Clusterio is starting up the server.  It can be used to
-initialize clusterio related features in a mod, and as a stand-in for
-the `on_init` and `on_configuration_changed` event for modules.  It is
-invoked on the first tick the server runs after the save has been
-patched, before most other events.
+Raised when Clusterio is starting up the server.
+It can be used to initialize clusterio related features in a mod, and as a stand-in for the `on_init` and `on_configuration_changed` event for modules.
+It is invoked on the first tick the server runs after the save has been patched, before most other events.
 
-Use this event to initialize and/or migrate the data structures
-you need.  Keep in mind that both mods and Clusterio modules can switch
-from any version to any version so it should be able to handle both
-forwards and backwards migrations gracefully.
+Use this event to initialize and/or migrate the data structures you need.
+Keep in mind that both mods and Clusterio modules can switch from any version to any version so it should be able to handle both forwards and backwards migrations gracefully.
 
 #### clusterio_api.send_json(channel, data)
 
-Send JSON data to Clusterio over the given channel.  The `data` argument
-should be table that can be serialized with `game.table_to_json`.
-Clusterio plugins can listen to channels and will receive an event with
-the data sent here.  See the [Communicating with Factorio
-section](writing-plugins.md#communicating-with-factorio) in the Writing
-Plugins document for more information.
+Send JSON data to Clusterio over the given channel.
+The `data` argument should be table that can be serialized with `game.table_to_json`.
+Clusterio plugins can listen to channels and will receive an event with the data sent here.
+See the [Communicating with Factorio section](writing-plugins.md#communicating-with-factorio) in the Writing Plugins document for more information.
 
-If the game is started outside of Clusterio the data will be sent, but
-since there's no code following stdout to pick it up it will be lost.
+If the game is started outside of Clusterio the data will be sent, but since there's no code following stdout to pick it up it will be lost.
 
 **Note**: Payloads greater than 4 MB will cause stuttering in the game.
 
-**Note**: This is not a binary safe way of sending data.  Strings
-embedded into the tables sent must be valid UTF-8 text.
+**Note**: This is not a binary safe way of sending data.
+Strings embedded into the tables sent must be valid UTF-8 text.
 
 Parameters:
 - `channel`: string identifying which channel to send it on.
@@ -348,19 +260,17 @@ From a module
 From a mod  
 `local serialize = require("__clusterio_lib__/serialize")`
 
-Serializes inventories and item stacks into a table that in turn can be
-converted into JSON with `game.table_to_json`.  Properly handles the
-extra data for most items.
+Serializes inventories and item stacks into a table that in turn can be converted into JSON with `game.table_to_json`.
+Properly handles the extra data for most items.
 
 #### serialize.serialize_equipment_grid(LuaEquipmentGrid)
 
-Returns a table containing a serialized representation of the equipment
-grid passed.
+Returns a table containing a serialized representation of the equipment grid passed.
 
 #### serialize.deserialize_equipment_grid(LuaEquipmentGrid, serialized_grid)
 
-Deserialize a previously serialized equipment grid into the target
-LuaEquipmentGrid.  Overwrites all content in the target.
+Deserialize a previously serialized equipment grid into the target LuaEquipmentGrid.
+Overwrites all content in the target.
 
 #### serialize.serialize_item_stack(LuaItemStack, destination_table)
 
@@ -369,23 +279,19 @@ The destination_table should be a new empty table.
 
 #### serialize.deserialize_item_stack(LuaItemStack, serialized_stack)
 
-Deserialize a previously serialized item stack into the target
-LuaItemStack.  Overwrites the content of the item stack.
+Deserialize a previously serialized item stack into the target LuaItemStack.
+Overwrites the content of the item stack.
 
 #### serialize.serialize_inventory(LuaInventory)
 
-Returns a table containing a serialized representation of the inventory
-passed.
+Returns a table containing a serialized representation of the inventory passed.
 
 #### serialize.deserialize_inventory(LuaInventory, serialized_inventory)
 
-Deserialize a previously serialized inventory into the target
-LuaInventory.  Overwrites slots that have content in the serialized
-inventory.
+Deserialize a previously serialized inventory into the target LuaInventory.
+Overwrites slots that have content in the serialized inventory.
 
 
-Clusterio Plugins
------------------
+## Clusterio Plugins
 
-See the [Writing Plugins](writing-plugins.md) document for details on
-the plugin interface and how to write plugins for Clusterio.
+See the [Writing Plugins](writing-plugins.md) document for details on the plugin interface and how to write plugins for Clusterio.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,30 +1,16 @@
-Save Patching
--------------
+## Save Patching
 
-In order to efficiently get data in and out of running Factorio servers
-and to provide custom interfaces Clusterio uses save
-patching<sup>[1]</sup> to add code to the game.  The save patching is
-based on the built in
-[event_handler](https://github.com/wube/factorio-data/blob/master/core/lualib/event_handler.lua)
-library to Factorio and requires scenarios to be coded specifically for
-it.  Mods on the other hand work without modifications.
+In order to efficiently get data in and out of running Factorio servers and to provide custom interfaces Clusterio uses save patching<sup>[1]</sup> to add code to the game.
+The save patching is based on the built in [event_handler](https://github.com/wube/factorio-data/blob/master/core/lualib/event_handler.lua) library to Factorio and requires scenarios to be coded specifically for it.
+Mods on the other hand work without modifications.
 
-This can be disabled with the `factorio.enable_save_patching` config on
-a per instance basis, however disabling it means that modules are not
-loaded into the game and most plugins will not function.
+This can be disabled with the `factorio.enable_save_patching` config on a per instance basis, however disabling it means that modules are not loaded into the game and most plugins will not function.
 
-<sub>1: Before version 2.0 of Clusterio this was done at runtime
-with a patcher called Hotpatch, but due to the difficulty in supporting
-run time patching and the lack of documentation it was replace it with
-save patching instead.</sub>
+<sub>1: Before version 2.0 of Clusterio this was done at runtime with a patcher called Hotpatch, but due to the difficulty in supporting run time patching and the lack of documentation it was replace it with save patching instead.</sub>
 
 
-User Accounts
--------------
+## User Accounts
 
-The master server creates and stores accounts for all Factorio users
-that log into instances under its control.  These accounts are used to
-store per player data and authorize management of the cluster.  By
-default users accounts are assigned a Player role that gives a limited
-read access to the cluster resources, and admins of the cluster can be
-assigned a Cluster Admin role to get access to manage it.
+The master server creates and stores accounts for all Factorio users that log into instances under its control.
+These accounts are used to store per player data and authorize management of the cluster.
+By default users accounts are assigned a Player role that gives a limited read access to the cluster resources, and admins of the cluster can be assigned a Cluster Admin role to get access to manage it.

--- a/docs/managing-a-cluster.md
+++ b/docs/managing-a-cluster.md
@@ -1,39 +1,27 @@
-Managing a Cluster
-==================
+# Managing a Cluster
 
-Clusterio clusters are managed through the master server by using the
-`clusterioctl` command line interface which is invoked by running
-`npx clusterioctl <command>` in the clusterio directory.  This document
-uses the shorthand `ctl> foo` to indicate `npx clusterioctl foo` should
-be executed.  Mandatory parameters are shown in `<angles bracket>` and
-optional pameters are in `[square brackets]`.
+Clusterio clusters are managed through the master server by using the `clusterioctl` command line interface which is invoked by running `npx clusterioctl <command>` in the clusterio directory.
+This document uses the shorthand `ctl> foo` to indicate `npx clusterioctl foo` should be executed.
+Mandatory parameters are shown in `<angles bracket>` and optional pameters are in `[square brackets]`.
 
-Before `clusterioctl` can be used it needs to be configured for the
-cluster it will connect to.  The easiest way to do this is to run
-`npx clusteriomaster bootstrap create-ctl-config <username>` on the
-master server, which creates the necessary `config-control.json` for
-managing the cluster as the given user.
+Before `clusterioctl` can be used it needs to be configured for the cluster it will connect to.
+The easiest way to do this is to run `npx clusteriomaster bootstrap create-ctl-config <username>` on the master server, which creates the necessary `config-control.json` for managing the cluster as the given user.
 
 
-Slaves
-------
+## Slaves
 
 To be written.
 
 
-Instances
----------
+## Instances
 
 To be written.
 
 
-Users
------
+## Users
 
-Clusterio automatically creates user accounts for all players that join
-an instance when save patching is enabled.  These accounts are used to
-store per player data shared between instances, like if the player
-should be whitelisted, admin or banned.
+Clusterio automatically creates user accounts for all players that join an instance when save patching is enabled.
+These accounts are used to store per player data shared between instances, like if the player should be whitelisted, admin or banned.
 
 ### List users
 
@@ -46,40 +34,32 @@ Lists all user accounts in the cluster along with some data for each.
 
     ctl> user create <name>
 
-Creates a new empty user account for the given Factorio player.  Note
-that case matters here.  This is usually not required as user accounts
-are created automatically for players that join instances with save
-patching enabled.
+Creates a new empty user account for the given Factorio player.
+Note that case matters here.
+This is usually not required as user accounts are created automatically for players that join instances with save patching enabled.
 
 
 ### Promote User to Server Admin
 
     ctl> user set-admin <name> [--revoke] [--create]
 
-Promotes the user given to in-game admin on instances with the
-`sync_adminlist` option enabled.  If the `--revoke` switch is used the
-user is removed from the adminlist.
+Promotes the user given to in-game admin on instances with the `sync_adminlist` option enabled.
+If the `--revoke` switch is used the user is removed from the adminlist.
 
-Since admin status is a part of the account data the account must exist
-for this to succeed, passing `--create` will create the account if it
-does not exist.
+Since admin status is a part of the account data the account must exist for this to succeed, passing `--create` will create the account if it does not exist.
 
-**Note:** Being a server admin does not grant any access to manage the
-cluster.  See [set-roles](#set-cluster-roles) for adding roles which
-grant access to managing the clusetr.
+**Note:** Being a server admin does not grant any access to manage the cluster.
+See [set-roles](#set-cluster-roles) for adding roles which grant access to managing the clusetr.
 
 
 ### Whitelist User
 
     ctl> user set-whitelisted <name> [--remove] [--create]
 
-Add the user given to the whitelist on instances with the
-`sync_whitelist` option enabled.  If the `--remove` switch is used the
-user is removed from the whitelist.
+Add the user given to the whitelist on instances with the `sync_whitelist` option enabled.
+If the `--remove` switch is used the user is removed from the whitelist.
 
-Since whitelisted status is a part of the account data the account must
-exist for this to succeed, passing `--create` will create the account if
-it does not exist.
+Since whitelisted status is a part of the account data the account must exist for this to succeed, passing `--create` will create the account if it does not exist.
 
 
 ### Ban User
@@ -87,16 +67,12 @@ it does not exist.
     ctl> user set-banned <name> [--reason <message>] [--pardon] [--create]
 
 Ban user in-game from instances with the `sync_banlist` option enabled.
-Reason is a message that will be shown to the user when attemption to
-log in.  If the `--pardon` switch is used it removes the ban.
+Reason is a message that will be shown to the user when attemption to log in.
+If the `--pardon` switch is used it removes the ban.
 
-Since ban status is a part of the account data the account must exist
-for this to succeed, passing `--create` will create the account if it
-does not exist.
+Since ban status is a part of the account data the account must exist for this to succeed, passing `--create` will create the account if it does not exist.
 
-Note: This bans the user from logging in to Factorio servers in the
-cluster, it does not revoke access to any cluster management they might
-have, see next section on setting roles for revoking tha.
+Note: This bans the user from logging in to Factorio servers in the cluster, it does not revoke access to any cluster management they might have, see next section on setting roles for revoking tha.
 
 
 ### Set Cluster Roles
@@ -104,13 +80,9 @@ have, see next section on setting roles for revoking tha.
     ctl> user set-roles <name> [roles...]
 
 Replaces the roles the user has in the cluster with a new list of roles.
-Calling with an empty roles argument will remove all roles from the
-user.
+Calling with an empty roles argument will remove all roles from the user.
 
-By default there's a roled named Cluster Admin which grants access to
-everything and a role named Player which grants a limited read access to
-the cluster, see [the section on roles](#roles) for more information
-about setting up roles and permissions.
+By default there's a roled named Cluster Admin which grants access to everything and a role named Player which grants a limited read access to the cluster, see [the section on roles](#roles) for more information about setting up roles and permissions.
 
 
 ### Delete user
@@ -119,14 +91,11 @@ about setting up roles and permissions.
 
 Deletes everything stored on the master server for this user.
 
-Note: If the player is banned from the cluster this will effectively
-unban them, as the ban status is stored with the user account.
+Note: If the player is banned from the cluster this will effectively unban them, as the ban status is stored with the user account.
 
-Note: If the player joins the cluster again a new account will be made
-for them automatically.
+Note: If the player joins the cluster again a new account will be made for them automatically.
 
 
-Roles
------
+## Roles
 
 To be written.

--- a/docs/setting-up-tls.md
+++ b/docs/setting-up-tls.md
@@ -1,54 +1,32 @@
-Setting up TLS
-==============
+# Setting up TLS
 
-By default Clusterio will listen for connections over HTTP which is fine
-for local networks but over the Internet it should idealy be over HTTPS
-as there are some credentials that could be exposed to eavesdroppers.
-The recommended setup is to have an ordinary HTTPS server software like
-Apache or Nginx to act as a reverse proxy in front of the Clusterio
-master server.  The reverse proxy would then be set up with a TLS
-certificate from a Certificate Authoritiy like [Let's
-Encrypt](https://letsencrypt.org).  Alternatively you can have Clusterio
-listen for connections over HTTPS directly by providing it with a TLS
-certificate and private key.
+By default Clusterio will listen for connections over HTTP which is fine for local networks but over the Internet it should idealy be over HTTPS as there are some credentials that could be exposed to eavesdroppers.
+The recommended setup is to have an ordinary HTTPS server software like Apache or Nginx to act as a reverse proxy in front of the Clusterio master server.
+The reverse proxy would then be set up with a TLS certificate from a Certificate Authoritiy like [Let's Encrypt](https://letsencrypt.org).
+Alternatively you can have Clusterio listen for connections over HTTPS directly by providing it with a TLS certificate and private key.
 
-Note that a TLS certificate signed by a recognized Certificate Authority
-in general requires that you own a domain.  See the last section for how
-to create and use a self-signed certificate for an IP address if you
-don't have a domain.
+Note that a TLS certificate signed by a recognized Certificate Authority in general requires that you own a domain.
+See the last section for how to create and use a self-signed certificate for an IP address if you don't have a domain.
 
 
-Using a reverse proxy
----------------------
+## Using a reverse proxy
 
-Configure the proxy to forward requests over HTTP to the port the master
-server is listening to so that for example a request to
-`https://example.com/instances/` is forwarded to
-`http://localhost:8080/instances/`.  It is possible to host the
-interface under a sub-path, in that case a request under the sub-path
-should be mapped to the master server with the sub-path stripped out.
-For example `https://example.com/sub/path/instances/` would be mapped to
-`http://localhost:8080/instances`.
+Configure the proxy to forward requests over HTTP to the port the master server is listening to so that for example a request to `https://example.com/instances/` is forwarded to `http://localhost:8080/instances/`.
+It is possible to host the interface under a sub-path, in that case a request under the sub-path should be mapped to the master server with the sub-path stripped out.
+For example `https://example.com/sub/path/instances/` would be mapped to `http://localhost:8080/instances`.
 
-Additianlly WebSocket connections to `/api/socket` also needs to be
-forwarded.  Typically this requires explicit configuration and support
-for forwarding WebSocket connections.  If the interface hosted under a
-sub-path the `/api/socket` address is relative to the sub-path and the
-sub-path also needs to be stripped out when forwarded.
+Additianlly WebSocket connections to `/api/socket` also needs to be forwarded.
+Typically this requires explicit configuration and support for forwarding WebSocket connections.
+If the interface hosted under a sub-path the `/api/socket` address is relative to the sub-path and the sub-path also needs to be stripped out when forwarded.
 
-You can also optionally set the master server to listen only on the
-loopback interface to prevent it being directly connected to from the
-outside.
+You can also optionally set the master server to listen only on the loopback interface to prevent it being directly connected to from the outside.
 
     npx clusteriomaster config set master.bind_address 127.0.0.1
 
 
 ### Apache Config
 
-To proxy with Apache make sure that `proxy_module`, `proxy_http_module`
-and `proxy_wstunnel_module` is loaded in the config, then add the
-following directives to wherever is the approriate place for your
-flavour of Apache config organization.
+To proxy with Apache make sure that `proxy_module`, `proxy_http_module` and `proxy_wstunnel_module` is loaded in the config, then add the following directives to wherever is the approriate place for your flavour of Apache config organization.
 
 ```apache
 <Location /sub/path/>
@@ -59,54 +37,36 @@ flavour of Apache config organization.
 </Location>
 ```
 
-Replace `/sub/path/` with the location on the proxy you want to host the
-Clusterio interface under.  If the whole domain is to be dedicated to
-the Clusterio interface then `/sub/path/` should be just `/`.  Pay
-attention to the use of trailing slashes, as they are important.
+Replace `/sub/path/` with the location on the proxy you want to host the Clusterio interface under.
+If the whole domain is to be dedicated to the Clusterio interface then `/sub/path/` should be just `/`.
+Pay attention to the use of trailing slashes, as they are important.
 
 
-Hosting HTTPS directly from Node.js
------------------------------------
+## Hosting HTTPS directly from Node.js
 
-Listening on HTTPS is supported by the Clusterio master server via the
-`master.https_port` option provided paths to a certificate file and a
-private key file is configured for the `master.tls_certificate` and
-`master.tls_private_key` options.  Both of these are expected to be
-unencrypted PEM files.
+Listening on HTTPS is supported by the Clusterio master server via the `master.https_port` option provided paths to a certificate file and a private key file is configured for the `master.tls_certificate` and `master.tls_private_key` options.
+Both of these are expected to be unencrypted PEM files.
 
 
-Creating and using a self-signed certificate
---------------------------------------------
+## Creating and using a self-signed certificate
 
 Create a self-signed certificate with OpenSSL by running
 
     openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 3650 -subj /CN=localhost -addext "subjectAltName=IP:<ip>"
 
-substituting `<ip>` with the IP address the server will be accessed
-under, for example `IP:203.0.113.4`.  Multiple addresses can be given by
-supplying a comma sepparated list of `IP:address` pairs and DNS names
-can also be specified using the `DNS:example.com` format.  You need to
-supply every name you want to connect to the server under the
-subjectAltName field, for example to connect to the HTTPS port locally
-via an address like `https://localhost:4443/` you need to add
-`DNS:localhost`.
+substituting `<ip>` with the IP address the server will be accessed under, for example `IP:203.0.113.4`.
+Multiple addresses can be given by supplying a comma sepparated list of `IP:address` pairs and DNS names can also be specified using the `DNS:example.com` format.
+You need to supply every name you want to connect to the server under the subjectAltName field, for example to connect to the HTTPS port locally via an address like `https://localhost:4443/` you need to add `DNS:localhost`.
 
-This creates a private key file named `key.pem` and a public certificate
-file named `cert.pem` and these are used for the
-`master.tls_certificate` and `master.tls_private_key` config options
-respectively on the master server:
+This creates a private key file named `key.pem` and a public certificate file named `cert.pem` and these are used for the `master.tls_certificate` and `master.tls_private_key` config options respectively on the master server:
 
     npx clusteriomaster config set master.tls_certificate cert.pem
     npx clusteriomaster config set master.tls_private_key key.pem
 
-Additionally you will need copy the `cert.pem` file to all of the
-computers you want to set up as slaves and configure it as the
-`slave.tls_ca` option:
+Additionally you will need copy the `cert.pem` file to all of the computers you want to set up as slaves and configure it as the `slave.tls_ca` option:
 
     npx clusterioslave config set slave.tls_ca cert.pem
 
-You will also need to copy the `cert.pem` file to all of the computers
-you want to remotely manage the cluster via clusterctl and configure it
-as `control.tls_ca` option:
+You will also need to copy the `cert.pem` file to all of the computers you want to remotely manage the cluster via clusterctl and configure it as `control.tls_ca` option:
 
     npx clusterioctl control-config set control.tls_ca cert.pem

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -1,13 +1,8 @@
-WebSocket protocol
-==================
+# WebSocket protocol
 
-<sub>This document describes the protocol used between the master and
-slaves, and unless you're developing Clusterio it's probably not going
-to be very useful for you.</sub>
-
-The protocol is built on WebSocket and uses JSON encoded text messages
-to communicate to and from the master server.  These messages contain
-a JSON encoded object with the following three properties:
+<sub>This document describes the protocol used between the master and slaves, and unless you're developing Clusterio it's probably not going to be very useful for you.</sub>
+The protocol is built on WebSocket and uses JSON encoded text messages to communicate to and from the master server.
+These messages contain a JSON encoded object with the following three properties:
 
 - seq - integer|null - The sequence number of the message
 - type - string - The type of message
@@ -16,98 +11,66 @@ a JSON encoded object with the following three properties:
 For the handshake and heartbeats the seq property is null.
 
 
-Handshake
----------
+## Handshake
 
-Upon connecting to the WebSocket endpoint the server will respond with a
-`hello` message containing the master server version as the data.  The
-client is then expected to send either `register_*` or a `resume`
-message to set up the connection with the master.  The exact flow is
-described below.
+Upon connecting to the WebSocket endpoint the server will respond with a `hello` message containing the master server version as the data.
+The client is then expected to send either `register_*` or a `resume` message to set up the connection with the master.
+The exact flow is described below.
 
 
 ### Client connection flow
 
-For a client making a new connecting to the master server the first
-course of action after obtaining a token is to connect with WebSocket to
-the /api/socket endpoint and wait for the server hello.  After the
-hello, the client sends a register\_\* message corresponding to the type
-of the client.  If successful the server will reply with a ready message
-and the connection has been established.  See the flowchart below.
+For a client making a new connecting to the master server the first course of action after obtaining a token is to connect with WebSocket to the /api/socket endpoint and wait for the server hello.
+After the hello, the client sends a register\_\* message corresponding to the type of the client.
+If successful the server will reply with a ready message and the connection has been established.
+See the flowchart below.
 
 ![Client connection flowchart](assets/connection_flow.svg)
 
-If for any reason the connection is closed or lost during the connection
-attempt the process is started over after a random delay, with the
-exception of the connection being closed with a 4003 code which means
-authentication failed and the client should stop trying to connect.  The
-wait for hello and wait for ready states should also have a timeout,
-after which the connection is closed if the hello/reply wasn't received
+If for any reason the connection is closed or lost during the connection attempt the process is started over after a random delay, with the exception of the connection being closed with a 4003 code which means authentication failed and the client should stop trying to connect.
+The wait for hello and wait for ready states should also have a timeout, after which the connection is closed if the hello/reply wasn't received
 in time.
 
 
 ### Client reconnection flow
 
-If the connection is lost after the client has received the ready
-message from the server it should attempt a reconnect instead.  This is
-very similar to a new connection, but instead of a register\_\* messsage
-the client sends a resume message and the server replies with a continue
-message if resuming the session was successful.  This continue message
-has sequence number of the last message the master received and the
-client is expected to imediately send all messages from its send buffer
-that occured after the sequence number given.
+If the connection is lost after the client has received the ready message from the server it should attempt a reconnect instead.
+This is very similar to a new connection, but instead of a register\_\* messsage the client sends a resume message and the server replies with a continue message if resuming the session was successful.
+This continue message has sequence number of the last message the master received and the client is expected to imediately send all messages from its send buffer that occured after the sequence number given.
 
-The server will respond with an invalidate message if resuming the
-session is not possible.  In this case the client should continue from
-the new session state of the connection flow (see the previous section).
+The server will respond with an invalidate message if resuming the session is not possible.
+In this case the client should continue from the new session state of the connection flow (see the previous section).
 
 ![Client reconnection flowchart](assets/reconnection_flow.svg)
 
-Like the connection flow the process starts over after a delay if the
-connection is closed or lost.  The same exception for connection closed
-with 4003 applies as with the connection flow.  Additionally after an
-invalidate message has been received and the connection flow fails, it
-should start over from the connection flow.
+Like the connection flow the process starts over after a delay if the connection is closed or lost.
+The same exception for connection closed with 4003 applies as with the connection flow.
+Additionally after an invalidate message has been received and the connection flow fails, it should start over from the connection flow.
 
 
 ### Server connection flow
 
-From the master server side new connections and reconnection attempts
-start out the same, a new connection has been made and the server sends
-the hello messoge to the client.  If a vaild register\_\* message is
-received a new connection is set up for the client and the ready message
-is sent in reply.  If a valid resume message is received and the session
-that's attempted to be resumed is active it'll signal that the session
-is resumed with a continue message and the client upon receiving the
-continue message should send the messages from its send buffer from
-after the last\_seq given in the continue message.
+From the master server side new connections and reconnection attempts start out the same, a new connection has been made and the server sends the hello messoge to the client.
+If a vaild register\_\* message is received a new connection is set up for the client and the ready message is sent in reply.
+If a valid resume message is received and the session that's attempted to be resumed is active it'll signal that the session is resumed with a continue message and the client upon receiving the continue message should send the messages from its send buffer from after the last\_seq given in the continue message.
 
-If the session token used to resume is not valid it'll send an invalidate
-message and expect the client to continue with a registr\_\* message.  If an
-invalid or unexpected message is received during the handshake the connection
-is closed.  See the flowchart below.
+If the session token used to resume is not valid it'll send an invalidate message and expect the client to continue with a registr\_\* message.
+If an invalid or unexpected message is received during the handshake the connection is closed.
+See the flowchart below.
 
 ![Client connection flowchart](assets/server_flow.svg)
 
-For authentication failure the connection is closed with code 4003,
-which the connection client should interpret as connecting will never
-succeed and stop trying to reconnect.
+For authentication failure the connection is closed with code 4003, which the connection client should interpret as connecting will never succeed and stop trying to reconnect.
 
 
 ### Connection tracking and heartbeats
 
-Once connected as indicated by the ready and continue messages from the
-master server the client must start sending heartbeats at the interval
-given in the ready/continue message, and storing messages sent over the
-link in a sending side buffer.  The heartbeats sent must have the seq of
-the last received message on the link and acts as an ack for received
-messages.  The master server also sends heartbeats in the same manner
-and the client should remove messages up to and including the sequence
-number received in the heartbeat from its send buffer.
+Once connected as indicated by the ready and continue messages from the master server the client must start sending heartbeats at the interval given in the ready/continue message, and storing messages sent over the link in a sending side buffer.
+The heartbeats sent must have the seq of the last received message on the link and acts as an ack for received messages.
+The master server also sends heartbeats in the same manner and the client should remove messages up to and including the sequence number received in the heartbeat from its send buffer.
 
 
-Handshake messages
-------------------
+## Handshake messages
 
 ### `hello`
 
@@ -115,8 +78,7 @@ Sent by the master server when the WebSocket connection has been opened.
 
 - version - string - The version of the master, e.g. "2.0.0".
 - plugins - Object&lt;string, string&gt; -
-    Object mapping plugin names to plugin version for plugins that are
-    loaded on the master server.
+    Object mapping plugin names to plugin version for plugins that are loaded on the master server.
 
 ### `register_slave`
 
@@ -128,8 +90,7 @@ Slave handshake for establishing a new connection session.
 - name - string - Name of the slave.
 - id - integer - ID of the slave.
 - plugins - Object&lt;string, string&gt; -
-    Object mapping plugin names to plugin version for plugins that are
-    available on the slave.
+    Object mapping plugin names to plugin version for plugins that are available on the slave.
 
 ### `register_control`
 
@@ -141,17 +102,15 @@ Control handshake for enstablishing a new connection session.
 
 ### `resume`
 
-Handshake for resuming an existing connection session where the
-connection had dropped unexpectedly.
+Handshake for resuming an existing connection session where the connection had dropped unexpectedly.
 
 - session_token - string - Session token to resume session with.
 - last_seq - integer|null - Last message seq received by the client.
 
 ### `invalidate`
 
-Sent by the master server in reply to a resume for a session that cannot
-be resumed.  The client should start a new session with a register\_\*
-message in response.
+Sent by the master server in reply to a resume for a session that cannot be resumed.
+The client should start a new session with a register\_\* message in response.
 
 ### `continue`
 
@@ -162,22 +121,19 @@ Sent by the master server to signal resuming the session was successful.
 
 ### `ready`
 
-Sent by the master server to signal the connection has been established
-with a new session.
+Sent by the master server to signal the connection has been established with a new session.
 
 - session_token - string - Token to resume the session with.
 - heartbeat_interval - number - Rate client should send heartbeats at.
 
 ### `heartbeat`
 
-Sent by both the master server and clients at the interval given in the
-continue/ready messages.
+Sent by both the master server and clients at the interval given in the continue/ready messages.
 
 - last_seq - integer - Last message seq received over the link.
 
 
-Example handshake
------------------
+## Example handshake
 
 Server hello after opening the WebSocket.
 
@@ -221,32 +177,23 @@ Master server reply signaling the session is established and ready.
 ```
 
 
-Events
-------
+## Events
 
-Events are messages send in one direction over the link, that the
-receiver is expected to act upon, but not make any replies (for that
-there's [Requests](#requests).  By convention message types ending in
-`*_event` are events.  The data payload of an event consists solely of
-event specific properties.
+Events are messages send in one direction over the link, that the receiver is expected to act upon, but not make any replies (for that there's [Requests](#requests).
+By convention message types ending in `*_event` are events.
+The data payload of an event consists solely of event specific properties.
 
-See [packages/lib/link/messages.js](/packages/lib/link/messages.js) for
-the recognized events and their contents.
+See [packages/lib/link/messages.js](/packages/lib/link/messages.js) for the recognized events and their contents.
 
 
-Requests
---------
+## Requests
 
-Requests are messages which expects a response in return.  They function
-a lot like HTTP requests except that both parties of a connection can
-inniate a request that is expected to be responded to.  By convention
-message types ending in `*_request` are requests, and is expected to be
-replied to with a corresponding `*_response` message.  If an error
-occured while processing the request an error response containing an
-error property in the data payload is sent instead.
+Requests are messages which expects a response in return.
+They function a lot like HTTP requests except that both parties of a connection can inniate a request that is expected to be responded to.
+By convention message types ending in `*_request` are requests, and is expected to be replied to with a corresponding `*_response` message.
+If an error occured while processing the request an error response containing an error property in the data payload is sent instead.
 
-See [packages/lib/link/messages.js](/packages/lib/link/messages.js) for
-the recognized requests and their contents.
+See [packages/lib/link/messages.js](/packages/lib/link/messages.js) for the recognized requests and their contents.
 
 ### `*_response`
 
@@ -259,29 +206,20 @@ the recognized requests and their contents.
 - error - string - Human readable text message describing the error.
 
 
-Graceful Disconnect
--------------------
+## Graceful Disconnect
 
-To ensure no data is lost when closing the link it's important to
-send a prepare disconnect request and wait for it to complete before
-closing the WebSocket.  Either party of the link can send this request
-and the party sending the request should be the one that initates the
-close of the WebSocket.
+To ensure no data is lost when closing the link it's important to send a prepare disconnect request and wait for it to complete before closing the WebSocket.
+Either party of the link can send this request and the party sending the request should be the one that initates the close of the WebSocket.
 
 ### `prepare_disconnect_request`
 
-Request graceful disconnect of the connection.  The receiving party should
-stop tasks that send events and requests over the link and wait for
-pending requests it has over the link to complete, but it should not
-stop responding to requests sent to it.  Only after this process is done
-should the response be sent.
+Request graceful disconnect of the connection.
+The receiving party should stop tasks that send events and requests over the link and wait for pending requests it has over the link to complete, but it should not stop responding to requests sent to it.
+Only after this process is done should the response be sent.
 
 ### `prepare_disconnect_response`
 
-Signals the preparation for disconnect is complete and that the
-connection can be closed.  The party that initiatied the prepare
-disconnect request may still send other requests/events over the link to
-finish its part of the disconnection proceedure.
+Signals the preparation for disconnect is complete and that the connection can be closed.
+The party that initiatied the prepare disconnect request may still send other requests/events over the link to finish its part of the disconnection proceedure.
 
-If the error response variant is received it should be logged if
-possible and treated as a success.
+If the error response variant is received it should be logged if possible and treated as a success.

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -1,13 +1,10 @@
-Writing Plugins
-===============
+# Writing Plugins
 
-Plugins for Clusterio are classes written in JavaScript that run under
-Node.js.  The plugin classes have pre-defined hooks that are called
-during various stages and operations of Clusterio.
+Plugins for Clusterio are classes written in JavaScript that run under Node.js.
+The plugin classes have pre-defined hooks that are called during various stages and operations of Clusterio.
 
 
-Contents
---------
+## Contents
 
 - [Plugin Structure](#plugin-structure)
 - [Defining the plugin class](#defining-the-plugin-class)
@@ -23,8 +20,7 @@ Contents
 - [Adding Custom Commands to clusterioctl](#adding-custom-commands-to-clusterioctl)
 
 
-Plugin Structure
-----------------
+## Plugin Structure
 
 The basic file structure of a plugin is the following.
 
@@ -40,21 +36,17 @@ The basic file structure of a plugin is the following.
          +- module.json
          +- plugin.lua
 
-Clusterio plugins are Node.js packages that can be published on npm for
-ease of installation and distribution.  The usual guides for creating
-such packages apply.  At minimum the `package.json` file must contain a
-version entry.
+Clusterio plugins are Node.js packages that can be published on npm for ease of installation and distribution.
+The usual guides for creating such packages apply.
+At minimum the `package.json` file must contain a version entry.
 
-A possible workflow for developing plugins is to place the plugin in a
-sub-directory of where clusterio has been installed, and rely on Node.js
-searching up the folder heirarchy for it to find `@clusterio/lib`.  To
-add it to `plugin-list.json` so that it gets loaded use the `plugin add
-<path>` sub-command to either clusteriomaster, clusterioslave or
-clusterioctl.  Note that it's important that the path starts with ./ or
-../ (use .\ or ..\ on Windows).
+A possible workflow for developing plugins is to place the plugin in a sub-directory of where clusterio has been installed, and rely on Node.js searching up the folder heirarchy for it to find `@clusterio/lib`.
+To add it to `plugin-list.json` so that it gets loaded use the `plugin add <path>` sub-command to either clusteriomaster, clusterioslave or clusterioctl.
+Note that it's important that the path starts with ./ or ../ (use .\ or ..\ on Windows).
 
-For a plugin the most important file is the `info.js` file.  Without it
-the plugin will not recognized by Clusterio.  Here's an example of it:
+For a plugin the most important file is the `info.js` file.
+Without it the plugin will not recognized by Clusterio.
+Here's an example of it:
 
     const libLink = require("@clusterio/lib/link"); // For messages
 
@@ -72,70 +64,58 @@ the plugin will not recognized by Clusterio.  Here's an example of it:
 The following properties are recognized:
 
 **name**:
-    Internal name of the plugin.  Must be the same as the plugin's
-    directory name
+    Internal name of the plugin.
+    Must be the same as the plugin's directory name
 
 **title**:
-    Name of the plugin as shown to users.  Currently not used.
+    Name of the plugin as shown to users.
+    Currently not used.
 
 **description**:
-    Brief description of what the plugin does.  Currently not used.
+    Brief description of what the plugin does.
+    Currently not used.
 
 **instanceEntrypoint**:
-    Path to a Node.js module relative to the plugin directory which
-    contains the InstancePlugin class definition for this plugin.  This
-    is an optional paramater.  A plugin may have code only for instances
-    but it must still be loaded on the master in order for it to be
-    possible to load it on an instance.
+    Path to a Node.js module relative to the plugin directory which contains the InstancePlugin class definition for this plugin.
+    This is an optional paramater.
+    A plugin may have code only for instances but it must still be loaded on the master in order for it to be possible to load it on an instance.
 
 **InstanceConfigGroup**:
-    Subclass of `PluginConfigGroup` for defining the per instance
-    configuration fields for this plugin.  See [Plugin
-    Configuration](#plugin-configuration)
+    Subclass of `PluginConfigGroup` for defining the per instance configuration fields for this plugin.
+    See [Plugin Configuration](#plugin-configuration)
 
 **masterEntrypoint**:
-    Path to a Node.js module relative to the plugin directory which
-    contains the MasterPlugin class definiton for this plugin.  This is
-    an optional parameter.  A plugin can be made that only runs on the
-    master server.
+    Path to a Node.js module relative to the plugin directory which contains the MasterPlugin class definiton for this plugin.
+    This is an optional parameter.
+    A plugin can be made that only runs on the master server.
 
 **MasterConfigGroup**:
-    Subclass of `PluginConfigGroup` for defining the master server
-    configuration fields for this plugin.  See [Plugin
-    Configuration](#plugin-configuration)
+    Subclass of `PluginConfigGroup` for defining the master server configuration fields for this plugin.
+    See [Plugin Configuration](#plugin-configuration)
 
 **controlEntrypoint**:
-    Path to a Node.js module relative to the plugin directory which
-    contains the ControlPlugin class definition for this plugin.  This
-    is an optional paramater.  A plugin can be made that only runs on
-    the clusterioctl side.
+    Path to a Node.js module relative to the plugin directory which contains the ControlPlugin class definition for this plugin.
+    This is an optional paramater.
+    A plugin can be made that only runs on the clusterioctl side.
 
 **messages**:
-    Object with link messages definitions for this plugin.  See guide
-    for [defining link messages](#defining-link-messages) below.
+    Object with link messages definitions for this plugin.
+    See guide for [defining link messages](#defining-link-messages) below.
 
-The optional module folder contains a Clusterio module that will be
-patched into the save when the plugin is loaded.  See the section on
-[Clusterio Modules](developing-for-clusterio.md) in the Developing for
-Clusterio document.  The only restriction imposed on modules embedded
-into plugins is that they must be named the same as the plugin.
+The optional module folder contains a Clusterio module that will be patched into the save when the plugin is loaded.
+See the section on [Clusterio Modules](developing-for-clusterio.md) in the Developing for Clusterio document.
+The only restriction imposed on modules embedded into plugins is that they must be named the same as the plugin.
 
-While there is no standard for how to organize a plugin it's recommended
-to put the MasterPlugin class definition into master.js and the
-InstancePlugin class definition into instance.js.  You can put them into
-whatever file you want (even the same one for both).
+While there is no standard for how to organize a plugin it's recommended to put the MasterPlugin class definition into master.js and the InstancePlugin class definition into instance.js.
+You can put them into whatever file you want (even the same one for both).
 
-For both instanceEntrypoint and masterEntrypoint the path should not end
-with .js and it should use forward slashes for directory separators if
-any.
+For both instanceEntrypoint and masterEntrypoint the path should not end with .js and it should use forward slashes for directory separators if any.
 
 
-Defining the plugin class
--------------------------
+## Defining the plugin class
 
-The plugin class should derive from its respective base class defined in
-`lib/plugin`.  For example, to define a MasterPlugin class the following
-code can be used:
+The plugin class should derive from its respective base class defined in `lib/plugin`.
+For example, to define a MasterPlugin class the following code can be used:
 
     const libPlugin = require("@clusterio/lib/plugin");
 
@@ -152,13 +132,11 @@ code can be used:
         MasterPlugin,
     }
 
-For the instance plugin it's exactly the same except "Master" is
-replaced with "Instance", and for the clusterioctl plugin "Control" is
-used.  The available hooks that you can override are documented in the
-base class [in lib/plugin.js](/packages/lib/plugin.js).
+For the instance plugin it's exactly the same except "Master" is replaced with "Instance", and for the clusterioctl plugin "Control" is used.
+The available hooks that you can override are documented in the base class [in lib/plugin.js](/packages/lib/plugin.js).
 
-It's best to avoid defining a constructor, but if you insist on defining
-one, forward all arguments to the base class.  E.g.:
+It's best to avoid defining a constructor, but if you insist on defining one, forward all arguments to the base class.
+E.g.:
 
         constructor(...args) {
             super(...args);
@@ -166,52 +144,41 @@ one, forward all arguments to the base class.  E.g.:
             // Code here
         }
 
-The arguments passed may change, and attempting to modify them will
-result in unpredicatable behaviour.  The async init method is always called
-immediatly after the constructor, so there's little reason to do this.
+The arguments passed may change, and attempting to modify them will result in unpredicatable behaviour.
+The async init method is always called immediatly after the constructor, so there's little reason to do this.
 
 
-Logging Messages
-----------------
+## Logging Messages
 
-The base plugin classes provide a winston logger for logging messages to
-the shared cluster log.  For instances a copy of the log is also stored
-on the slave the instance is on.  To use it, pass a string to one of the
-log levels functions, for example:
+The base plugin classes provide a winston logger for logging messages to the shared cluster log.
+For instances a copy of the log is also stored on the slave the instance is on.
+To use it, pass a string to one of the log levels functions, for example:
 
     async init() {
         this.logger.info("Initializing frobbing");
     }
 
-Metadata covering which plugin and instance (for instance plugin
-classes) the log event happened on will automatically be attached to the
-log message.
+Metadata covering which plugin and instance (for instance plugin classes) the log event happened on will automatically be attached to the log message.
 
 The available levels are fatal, error, warn, audit, info, and verbose.
 These levels have roughly the following meanings:
 
-- fatal: Unrecoverable error that prevents continuing execution of
-  the Node.js process.  Note that Plugins shouldn't have fatal errors.
-- error: An unexpected error condition occured, usually an exception
-  thrown when it wasn't expected.  Should be investigated and fixed.
-- warn: An potential error was detected, but operation continued
-  gracefully.  These may indicate that something is running
-  sub-optimally, or is not working as intedend.
-- audit: Record of actions performed by users of the cluster.  This
-  is usually emitted in response to management requests by a control
-  link.
-- info: A general log message.  May indicae a status or operation
-  completed.  This should not be emitted by periodic tasks that run
-  often.
-- verbose: A verbose log message which might be useful when
-  investigating issues, does not show by default.  Note that logging
-  messages is not a cheap operation even when the messages do not show
-  up and spammy logging should be avoided for the verbose level.
-  If the logs are still valuable in certain cases consider putting them
-  behind a config option.
+- fatal: Unrecoverable error that prevents continuing execution of the Node.js process.
+  Note that Plugins shouldn't have fatal errors.
+- error: An unexpected error condition occured, usually an exception thrown when it wasn't expected.
+  Should be investigated and fixed.
+- warn: An potential error was detected, but operation continued gracefully.
+  These may indicate that something is running sub-optimally, or is not working as intedend.
+- audit: Record of actions performed by users of the cluster.
+  This is usually emitted in response to management requests by a control link.
+- info: A general log message.
+  May indicae a status or operation completed.
+  This should not be emitted by periodic tasks that run often.
+- verbose: A verbose log message which might be useful when investigating issues, does not show by default.
+  Note that logging messages is not a cheap operation even when the messages do not show up and spammy logging should be avoided for the verbose level.
+  If the logs are still valuable in certain cases consider putting them behind a config option.
 
-For guarding unexpected errors the best option is to log a short
-description along with the`stack` property of the Error:
+For guarding unexpected errors the best option is to log a short description along with the`stack` property of the Error:
 
     try {
         // Operation that should not throw but may end up throwing
@@ -219,21 +186,14 @@ description along with the`stack` property of the Error:
         this.logger.error(`Operation failed:\n${err.stack}`);
     )
 
-For plugin hooks expections thrown are automatically catched and logged,
-but for event handlers registered on EventEmitters it's critical that
-exceptions are catched and handled appropriately.
+For plugin hooks expections thrown are automatically catched and logged, but for event handlers registered on EventEmitters it's critical that exceptions are catched and handled appropriately.
 
 
-Plugin Configuration
---------------------
+## Plugin Configuration
 
-Clusterio provides a configuration system that handles storing,
-distributing, editing and validating config fields for you.  You can
-take advantage of it by subclassing `PluginConfigGroup`, setting
-`defaultAccess` to where config entries can be accessed from, setting the
-`groupName` to your plugin name, defining fields on it, finalizing it,
-and passing it as either `MasterConfigGroup` or `InstanceConfigGroup` in
-the `info.js` export.  For example in info.js:
+Clusterio provides a configuration system that handles storing, distributing, editing and validating config fields for you.
+You can take advantage of it by subclassing `PluginConfigGroup`, setting `defaultAccess` to where config entries can be accessed from, setting the `groupName` to your plugin name, defining fields on it, finalizing it, and passing it as either `MasterConfigGroup` or `InstanceConfigGroup` in the `info.js` export.
+For example in info.js:
 
     const libConfig = require("@clusterio/lib/config");
 
@@ -253,26 +213,22 @@ the `info.js` export.  For example in info.js:
         MasterConfigGroup: MasterConfigGroup,
     };
 
-Code inside the `MasterPlugin` class will then be able to access the
-level config field through the `Config` object at `this.master.config`,
-for example in the MasterPluginClass:
+Code inside the `MasterPlugin` class will then be able to access the level config field through the `Config` object at `this.master.config`, for example in the MasterPluginClass:
 
     async init() {
         let level = this.master.config.get("foo_frobber.level");
         this.logger.info(`I got a frobnication level of ${level}`);
     }
 
-The same applies for instance configs, replace "master" with "instance"
-where appropriate.  See [Configuration System](config-system.md)
-for more details on how this system works.
+The same applies for instance configs, replace "master" with "instance" where appropriate.
+See [Configuration System](config-system.md) for more details on how this system works.
 
 
 ### Handling Invalid Configuration
 
-If the plugin requires a certain feature to be enabled to function it
-should throw an error during init if this is not the case.  The most
-common such feature is the save patching, which can be disabled to run
-vanilla or scenarios not compatible with Clusterio.  For example:
+If the plugin requires a certain feature to be enabled to function it should throw an error during init if this is not the case.
+The most common such feature is the save patching, which can be disabled to run vanilla or scenarios not compatible with Clusterio.
+For example:
 
     async init() {
         if (!this.instance.config.get("factorio.enable_save_patching")) {
@@ -281,11 +237,9 @@ vanilla or scenarios not compatible with Clusterio.  For example:
     }
 
 
-Communicating with Factorio
----------------------------
+## Communicating with Factorio
 
-For pushing data into Factorio there's RCON, which lets you send
-arbitrary Lua commands to invoke whatever code you want in the game.
+For pushing data into Factorio there's RCON, which lets you send arbitrary Lua commands to invoke whatever code you want in the game.
 This is done by calling the `sendRcon` method on the plugin object.
 For example:
 
@@ -298,19 +252,14 @@ For example:
     }
 
 
-Because data into Factorio is streamed at a rate of 3-6 kB/s by default,
-it is recommended to avoid sending large commands as much as possible,
-and to strip down the data on the ones you send to only what's strictly
-necessary.  You can have lua code injected into the game via the module
-system and call that from RCON to avoid having to send code through the
-commands.
+Because data into Factorio is streamed at a rate of 3-6 kB/s by default, it is recommended to avoid sending large commands as much as possible, and to strip down the data on the ones you send to only what's strictly necessary.
+You can have lua code injected into the game via the module system and call that from RCON to avoid having to send code through the commands.
 
-For getting data out from Factorio there's both RCON and the `send_json`
-API of the Clusterio module.  Returning data via RCON is prefered if the
-action is initiated from the Node.js side.  The `send_json` API allows
-sending JSON payloads on channels that plugins can listen to.  From a
-plugin you listen for an event named `ipc-channel_name` in order to get
-data sent by `send_json`.  For example in the plugin code:
+For getting data out from Factorio there's both RCON and the `send_json` API of the Clusterio module.
+Returning data via RCON is prefered if the action is initiated from the Node.js side.
+The `send_json` API allows sending JSON payloads on channels that plugins can listen to.
+From a plugin you listen for an event named `ipc-channel_name` in order to get data sent by `send_json`.
+For example in the plugin code:
 
     async init() {
         this.instance.server.on("ipc-my_plugin_foo", content =>
@@ -331,52 +280,35 @@ And then in the module for the plugin:
     -- inside some event handler
     clusterio_api.send_json("my_plugin_foo", { data = 123 })
 
-It's recommended to either use the plugin name as the channel name or to
-prefix the channel name with the name of the plugin if you need multiple
-channels.  It's also important to catch any errors that might occur as
-they will otherwise be propogated to the instance code and kill the
-server.
+It's recommended to either use the plugin name as the channel name or to prefix the channel name with the name of the plugin if you need multiple channels.
+It's also important to catch any errors that might occur as they will otherwise be propogated to the instance code and kill the server.
 
-Data out from Factorio does not have the same limits as data into
-Factorio, RCON responses can be in 100kB range without causing issues,
-and payloads to the `send_json` API can be in the 4MB range provided the
-server has a fast enough storage system.
+Data out from Factorio does not have the same limits as data into Factorio, RCON responses can be in 100kB range without causing issues, and payloads to the `send_json` API can be in the 4MB range provided the server has a fast enough storage system.
 
-**Note:** both `send_json` and RCON can operate out of order.  For
-`send_json` it's possible that payloads greater than 4kB are received
-after payloads that were sent at a later point in time.  For RCON,
-commands longer than 50 characters may end up being executed after
-shorter commands sent after it.
+**Note:** both `send_json` and RCON can operate out of order.
+For `send_json` it's possible that payloads greater than 4kB are received after payloads that were sent at a later point in time.
+For RCON, commands longer than 50 characters may end up being executed after shorter commands sent after it.
 
 
-Defining Link Messages
-----------------------
+## Defining Link Messages
 
-You will most likely have to communicate with the master or other
-instances in your plugin for it to do anything useful.  For this there's
-a WebSocket communication channel established between the slaves and the
-master server that plugins can define their own messages to send over
-it.  This channel is bi-directional and all messages sent over it are
-validated with a JSON schema (see [this guide][guide] for an
-introduction to writing JSON schema).
+You will most likely have to communicate with the master or other instances in your plugin for it to do anything useful.
+For this there's a WebSocket communication channel established between the slaves and the master server that plugins can define their own messages to send over it.
+This channel is bi-directional and all messages sent over it are validated with a JSON schema (see [this guide][guide] for an introduction to writing JSON schema).
 
 [guide]: https://json-schema.org/learn/getting-started-step-by-step.html
 
-There are currently two kinds of messages that can be defined: events
-and requests.  Events are simple one-way notifications that invoke a
-handler on the target it's sent to.  Requests are pairs of request and
-response messages where the request is sent to the target and the
-response is the reply back from the target.  The requests are similar to
-HTTP requests, except both parties of a link may initiate one.
+There are currently two kinds of messages that can be defined: events and requests.
+Events are simple one-way notifications that invoke a handler on the target it's sent to.
+Requests are pairs of request and response messages where the request is sent to the target and the response is the reply back from the target.
+The requests are similar to HTTP requests, except both parties of a link may initiate one.
 
 
 ### Defining Events
 
-Events are defined as properties of the messages object exported by
-`info.js` that map to instances of the `Event` class from `lib/link`.
-The name of the property correspond to the handler invoked on the plugin
-class.  The Event constructor takes an object of properties that define
-the event, for example the following could be defined in `info.js`:
+Events are defined as properties of the messages object exported by `info.js` that map to instances of the `Event` class from `lib/link`.
+The name of the property correspond to the handler invoked on the plugin class.
+The Event constructor takes an object of properties that define the event, for example the following could be defined in `info.js`:
 
     messages: {
         startFrobnication: new libLink.Event({
@@ -391,86 +323,65 @@ the event, for example the following could be defined in `info.js`:
         }),
     },
 
-This specifies an event that can be sent from the master to a slave,
-and from a slave to an instance.  It also specifies that the event must
-contain the property `frobnication_type`, with a string value in the
-data payload and that it may optionally contain a boolean `urgent`
-property.  It will also be forwarded by slaves to a specific instance.
+This specifies an event that can be sent from the master to a slave, and from a slave to an instance.
+It also specifies that the event must contain the property `frobnication_type`, with a string value in the data payload and that it may optionally contain a boolean `urgent` property.
+It will also be forwarded by slaves to a specific instance.
 
 The following properties are recognized by the Event constructor:
 
 #### type
 
-The message type sent over the wire.  This must start with the name of
-the plugin followed by colon and and be unique for the plugin.  The type
-of the message sent over the socket will have the suffix `_event`
-appended to it.
+The message type sent over the wire.
+This must start with the name of the plugin followed by colon and and be unique for the plugin.
+The type of the message sent over the socket will have the suffix `_event` appended to it.
 
 #### links
 
 An array of strings describing which links this event can be sent over.
-Direction matters, `"master-slave"` means the event can be sent from the
-master to the slave, but can't be sent back the other way, unless
-`"slave-master"` is also present in the links array.
+Direction matters, `"master-slave"` means the event can be sent from the master to the slave, but can't be sent back the other way, unless `"slave-master"` is also present in the links array.
 
-The available endpoints are `master`, `slave`, `instance`, and
-`control`.  Master talks with slave and control, and slave talks to
-instance.  The full chain must be specified as the individual links in
-order for a message to travers multiple hops, (i.e., for a message to go
-from master to instance it must have both `"master-slave"` and
-`"slave-instance"` in the links array).  See `forwardTo` and
-`broadcastTo` for ways to forward an event to the next link in a chain.
+The available endpoints are `master`, `slave`, `instance`, and `control`.
+Master talks with slave and control, and slave talks to instance.
+The full chain must be specified as the individual links in order for a message to travers multiple hops, (i.e., for a message to go from master to instance it must have both `"master-slave"` and `"slave-instance"` in the links array).
+See `forwardTo` and `broadcastTo` for ways to forward an event to the next link in a chain.
 
 #### forwardTo
 
-Target to forward an event to.  Can either be `"master"`, to indicate a
-slave should forward it to the master server, or `"instance"`, to
-indicate it should be forwarded to the instances specified by the
-`instance_id` event property.  This works by using a default handler for
-the event at the links that forward it.
+Target to forward an event to.
+Can either be `"master"`, to indicate a slave should forward it to the master server, or `"instance"`, to indicate it should be forwarded to the instances specified by the `instance_id` event property.
+This works by using a default handler for the event at the links that forward it.
 
 #### broadcastTo
 
-Target to broadcast this message towards.  A value of "instance" means
-the event will be broadcast to all instances downstream of the target
-it's sent to, but not back from where it came from. Currently, only
-"instance" is supported. This means that sending an event to a slave
-that slave except for the instance it came from.  from an instance will
-cause it to be broadcast to all instances of
+Target to broadcast this message towards.
+A value of "instance" means the event will be broadcast to all instances downstream of the target it's sent to, but not back from where it came from.
+Currently, only "instance" is supported.
+This means that sending the event to a slave from an instance will cause it to be broadcast to all instances of that slave except for the instance it came from.
 
 #### eventRequired
 
-By default all properties defined in `eventProperties` are required to
-be present in the payload for the event.  This can be overriden by
-specifying an array of properties which are required here.  This is
-equivalent to using the `required` keyword in JSON schema.
+By default all properties defined in `eventProperties` are required to be present in the payload for the event.
+This can be overriden by specifying an array of properties which are required here.
+This is equivalent to using the `required` keyword in JSON schema.
 
 #### eventProperties
 
-Object with properties mapping to a JSON schema of that property that
-specifies what's valid to send in the event.  This is equivalent to
-using the `properties` keyword in JSON schema, except that the
-properties specified are by default required and additional properties
-are not allowed.  See [this guide][guide] for an introduction to writing
-JSON schemas.
+Object with properties mapping to a JSON schema of that property that specifies what's valid to send in the event.
+This is equivalent to using the `properties` keyword in JSON schema, except that the properties specified are by default required and additional properties are not allowed.
+See [this guide][guide] for an introduction to writing JSON schemas.
 
-The forwardTo and broadcastTo can be combined such that specifying
-`"master"` as the forwardTo value and `"instance"` as the broadcastTo
-value will cause the event to be broadcast to all instances in the
-cluster.  For this to work, you will need to specify `instance-slave`,
-`slave-master`, `master-slave`, and `slave-instance` as the links.
+The forwardTo and broadcastTo can be combined such that specifying `"master"` as the forwardTo value and `"instance"` as the broadcastTo value will cause the event to be broadcast to all instances in the cluster.
+For this to work, you will need to specify `instance-slave`, `slave-master`, `master-slave`, and `slave-instance` as the links.
 
-Keep in mind when forwarding events that if the target an event is being
-forwarded to is not online, the event will be dropped.  Use a request if
-you need a confirmation that the message was received.
+Keep in mind when forwarding events that if the target an event is being forwarded to is not online, the event will be dropped.
+Use a request if you need a confirmation that the message was received.
 
 ### Definining Requests
 
-Requests are defined as properties of the messages object exported by
-`info.js` that map to instances of the `Request` class from `lib/link`.
-The name of the property corresponds to the handler invoked on the plugin
-class.  The Request constructor takes an object of properties that define
-the event. For example, the following could be defined in `info.js`:
+Requests are defined as properties of the messages object exported by `info.js` that map to instances of the `Request` class from `lib/link`.
+The name of the property corresponds to the handler invoked on the plugin class.
+The Request constructor takes an object of properties that define the event.
+For example, the following could be defined in `info.js`:
 
     messages: {
         reportFrobnication: new libLink.Request({
@@ -491,151 +402,103 @@ the event. For example, the following could be defined in `info.js`:
         }),
     },
 
-This specifies a request that can be sent from the master to a slave,
-and from a slave to an instance.  The request data must contain the
-property `verbosity` with an integer number as the value, as well as the
-`instance_id` property (implied by `forwardTo: "instance"`) and it may
-also contain a boolean `special` property.  It also defines that the
-response sent must contain a `report` property mapping to an array of
-strings.  When received by a slave, it will also be forwarded to the
-instance specified by `instance_id`.
+This specifies a request that can be sent from the master to a slave, and from a slave to an instance.
+The request data must contain the property `verbosity` with an integer number as the value, as well as the `instance_id` property (implied by `forwardTo: "instance"`) and it may also contain a boolean `special` property.
+It also defines that the response sent must contain a `report` property mapping to an array of strings.
+When received by a slave, it will also be forwarded to the instance specified by `instance_id`.
 
 The following properties are recognized by the Request constructor:
 
 #### type
 
-The message type sent over the wire.  This must start with the name of
-the plugin followed by colon and and be unique for the plugin.  The type
-of the message sent over the socket will have the suffix `_request`
-appended to it for the request and `_response` appended to it for the
-response.
+The message type sent over the wire.
+This must start with the name of the plugin followed by colon and and be unique for the plugin.
+The type of the message sent over the socket will have the suffix `_request` appended to it for the request and `_response` appended to it for the response.
 
 #### links
 
-An array of strings describing which links this request can be sent
-over.  Direction matters; `"master-slave"` means the request can be sent
-from the master to the slave and the slave can reply to the master, but
-the slave can't send a request to the master unless `"slave-master"` is
-also present in the links array.
+An array of strings describing which links this request can be sent over.
+Direction matters; `"master-slave"` means the request can be sent from the master to the slave and the slave can reply to the master, but the slave can't send a request to the master unless `"slave-master"` is also present in the links array.
 
-The available endpoints are `master`, `slave`, `instance`, and
-`control`.  Master talks with slave and control, and slave talks to
-instance.  The full chain must be specified as the individual links in
-order for a message to travers multiple hops, (i.e., for a message to go
-from master to instance it must have both `"master-slave"` and
-`"slave-instance"` in the links array).  See `forwardTo` for ways to
-forward a request to the next link in a chain.
+The available endpoints are `master`, `slave`, `instance`, and `control`.
+Master talks with slave and control, and slave talks to instance.
+The full chain must be specified as the individual links in order for a message to travers multiple hops, (i.e., for a message to go from master to instance it must have both `"master-slave"` and `"slave-instance"` in the links array).
+See `forwardTo` for ways to forward a request to the next link in a chain.
 
 #### forwardTo
 
-Target to forward the request to.  Can either be `"master"` to indicate
-a slave should forward it to the master server when receiving it from an
-instance, or `"instance"` to indicate it should be forwarded to the
-instances specified by the `instance_id` request property.  This works
-by using a default handler for the request by the links that forward it.
+Target to forward the request to.
+Can either be `"master"` to indicate a slave should forward it to the master server when receiving it from an instance, or `"instance"` to indicate it should be forwarded to the instances specified by the `instance_id` request property.
+This works by using a default handler for the request by the links that forward it.
 
 #### requestRequired
 
-By default all properties defined in `requestProperties` are required to
-be present in the payload for the request.  This can be overriden by
-specifying an array of properties which are required here.  This is
-equivalent to using the `required` keyword in JSON schema.
+By default all properties defined in `requestProperties` are required to be present in the payload for the request.
+This can be overriden by specifying an array of properties which are required here.
+This is equivalent to using the `required` keyword in JSON schema.
 
 #### requestProperties
 
-Object with properties mapping to a JSON schema of that property that
-specifies what's valid to send in the request.  This is equivalent to
-using the `properties` keyword in JSON schema, except that the
-properties specified are by default required and additional properties
-are not allowed.  See [this guide][guide] for an introduction to writing
-JSON schemas
+Object with properties mapping to a JSON schema of that property that specifies what's valid to send in the request.
+This is equivalent to using the `properties` keyword in JSON schema, except that the properties specified are by default required and additional properties are not allowed.
+See [this guide][guide] for an introduction to writing JSON schemas
 
 #### responseRequired
 
-Same as the requestRequired only for the response sent back by the
-target.
+Same as the requestRequired only for the response sent back by the target.
 
 #### responseProperties
 
-Same as the requestProperties only for the response sent back by the
-target.
+Same as the requestProperties only for the response sent back by the target.
 
 
-Sending Link Messages
----------------------
+## Sending Link Messages
 
-Link messages are sent by calling the `.send()` method on the
-Event/Request instance with the link you want to send it over and the
-data to send. For `InstancePlugin` code the link to the slave is the
-`instance` itself, which is accessible through the `.instance` property
-of the `InstancePlugin`. The `.info` property of the plugin class exposes
-the data exported from the plugin's `info.js` module.  In other words:
+Link messages are sent by calling the `.send()` method on the Event/Request instance with the link you want to send it over and the data to send.
+For `InstancePlugin` code the link to the slave is the `instance` itself, which is accessible through the `.instance` property of the `InstancePlugin`.
+The `.info` property of the plugin class exposes the data exported from the plugin's `info.js` module.
+In other words:
 
     // In an InstancePlugin class
     async frobnicate() {
         this.info.messages.exampleEvent.send(this.instance, { foo: "bar" });
     }
 
-For the Request class the send method is async and returns the response
-data received from the target it was sent to, or throws an error if the
-request failed.
+For the Request class the send method is async and returns the response data received from the target it was sent to, or throws an error if the request failed.
 
 
 ### Handling connection events
 
-There are a few connection related events that plugins neeed to repsond
-to in order to avoid data loss and connection problems.  The most
-important is the prepare disconnect for the link between master and
-slave.  This is signaled to `MasterPlugin` classes via the
-`onPrepareSlaveDisconnect` hook and to `InstancePlugin` classes via the
-`onPrepareMasterDisconnect` hook.
+There are a few connection related events that plugins neeed to repsond to in order to avoid data loss and connection problems.
+The most important is the prepare disconnect for the link between master and slave.
+This is signaled to `MasterPlugin` classes via the `onPrepareSlaveDisconnect` hook and to `InstancePlugin` classes via the `onPrepareMasterDisconnect` hook.
 
-After the prepare disconnect the connection will be closed, which will
-result in pending requests and events being dropped.  Plugins must
-respond to the prepare disconnect by stopping any processess it does
-that send events or requests over the link in question.  This can be
-accomplished either through listening for the prepare disconnect hook,
-or by checking the `connected` or `closing` property of the connector
-for the master/slave connection.  For example the sending of an event
-from an `InstancePlugin` class can be stopped while the connection is
-closing by using the following code:
+After the prepare disconnect the connection will be closed, which will result in pending requests and events being dropped.
+Plugins must respond to the prepare disconnect by stopping any processess it does that send events or requests over the link in question.
+This can be accomplished either through listening for the prepare disconnect hook, or by checking the `connected` or `closing` property of the connector for the master/slave connection.
+For example the sending of an event from an `InstancePlugin` class can be stopped while the connection is closing by using the following code:
 
     if (!this.slave.connector.closing) {
         this.info.messages.frobnicate.send(this.instance, { foo: "bar" });
     }
 
-If the event or request needs to be sent to the master it can be put
-into a queue stored on the plugin instance and sent out when the
-connection is established again.  The re-establishement of the
-connection is  notified to plugins via the `connect` event to the
-`onMasterConnectionEvent` and `onSlaveConnectionEvent` hooks.
+If the event or request needs to be sent to the master it can be put into a queue stored on the plugin instance and sent out when the connection is established again.
+The re-establishement of the connection is  notified to plugins via the `connect` event to the `onMasterConnectionEvent` and `onSlaveConnectionEvent` hooks.
 
-The second connection event which is of lesser importance to respond to
-is the `drop` connection event served through `onMasterConnectionEvent`
-for `InstancePlugin` classes and through `onSlaveConnectionEvent` for
-`MasterPlugin` classes.  This is raised when the connection between the
-master and slave in question is lost, most likely due to networking
-issues.  When in the dropped state the slave will keep trying to
-reconnect to the master server in order to re-establish it, and if
-successful no events or requests will be lost.  However while in the
-dropped state any requests and events sent gets queued up in memory
-until the connection is re-established.  This means that if your plugin
-sends a lot of events or requests, they can end up being queued up in a
-buffer for a long time and sent out all at once.  To avoid this you
-should be throtteling and/or stopping your requests/events after `drop`
-has been raised, and continue back as normal when `resume` is raised.
+The second connection event which is of lesser importance to respond to is the `drop` connection event served through `onMasterConnectionEvent` for `InstancePlugin` classes and through `onSlaveConnectionEvent` for `MasterPlugin` classes.
+This is raised when the connection between the master and slave in question is lost, most likely due to networking issues.
+When in the dropped state the slave will keep trying to reconnect to the master server in order to re-establish it, and if successful no events or requests will be lost.
+However while in the dropped state any requests and events sent gets queued up in memory until the connection is re-established.
+This means that if your plugin sends a lot of events or requests, they can end up being queued up in a buffer for a long time and sent out all at once.
+To avoid this you should be throtteling and/or stopping your requests/events after `drop` has been raised, and continue back as normal when `resume` is raised.
 
 
-Collecting Statistics
----------------------
+## Collecting Statistics
 
-Clusterio comes with its own Prometheus client implementation, one part
-due to Not Invented Here and another part due to collectors in
-prom-client being difficult to get to work nicely with collecting data
-from plugins optionally loaded at runtime on different computers.
+Clusterio comes with its own Prometheus client implementation, one part due to Not Invented Here and another part due to collectors in prom-client being difficult to get to work nicely with collecting data from plugins optionally loaded at runtime on different computers.
 
-In its simplest form collecting data from plugins consists of defining
-the metric and updating it somewhere in the plugin code.  For example:
+In its simplest form collecting data from plugins consists of defining the metric and updating it somewhere in the plugin code.
+For example:
 
     const { Counter } = require("@clusterio/lib/prometheus");
 
@@ -646,13 +509,10 @@ the metric and updating it somewhere in the plugin code.  For example:
     // Somewhere in the master plugin code
     fooMetric.inc();
 
-This works for master plugins, and the metric will be automatically
-available through the /metric HTTP endpoint.  It's recommended that
-plugin metrics follow `clusterio_<plugin_name>_<metric_name>` as the
-naming scheme.
+This works for master plugins, and the metric will be automatically available through the /metric HTTP endpoint.
+It's recommended that plugin metrics follow `clusterio_<plugin_name>_<metric_name>` as the naming scheme.
 
-For metrics that are per-instance, you must define an `instance_id` label and
-set it accordingly, for example:
+For metrics that are per-instance, you must define an `instance_id` label and set it accordingly, for example:
 
     const { Counter } = require("@clusterio/lib/prometheus");
 
@@ -664,26 +524,17 @@ set it accordingly, for example:
     // Somewhere in the instance plugin code
     barMetric.labels(String(this.instance.id)).set(someValue);
 
-Metrics are automatically registered to the default registry, and this
-default registry is automatically polled by the master server on slaves.
-This means that it's important that you place the definition of the
-metric at module level so that it's not created more than once over the
-lifetime of a slave.  Since the metrics remember their values and would
-continue to be exported after an instance is shutdown, there's code at
-instance shutdown that removes all the values where the `instance_id`
-label matches the id of the instance shut down.
+Metrics are automatically registered to the default registry, and this default registry is automatically polled by the master server on slaves.
+This means that it's important that you place the definition of the metric at module level so that it's not created more than once over the lifetime of a slave.
+Since the metrics remember their values and would continue to be exported after an instance is shutdown, there's code at instance shutdown that removes all the values where the `instance_id` label matches the id of the instance shut down.
 
-For statistics you need to update on collection there's an `onMetrics`
-hook on both master and instance plugins that is run before the
-metrics in the default registry are collected.
+For statistics you need to update on collection there's an `onMetrics` hook on both master and instance plugins that is run before the metrics in the default registry are collected.
 
 
-Adding Custom Commands to clusterioctl
---------------------------------------
+## Adding Custom Commands to clusterioctl
 
-The control entrypoint for plugins allows you to extend clustectl with
-your own commands.  The creation of custom commands typically starts
-with defining a command tree for the plugin:
+The control entrypoint for plugins allows you to extend clustectl with your own commands.
+The creation of custom commands typically starts with defining a command tree for the plugin:
 
     const { Command, CommandTree } = require("@clusterio/lib/command");
     const fooFrobberCommands = new CommandTree({
@@ -708,25 +559,13 @@ Then commands are added to the the plugin's command tree:
         },
     }));
 
-For a command the `definition` is the arguments to pass to
-[yargs.command](http://yargs.js.org/docs/#api-reference-commandcmd-desc-builder-handler)
-(see also
-[yargs.positional](http://yargs.js.org/docs/#api-reference-positionalkey-opt)
-and
-[yargs.options](http://yargs.js.org/docs/#api-reference-optionskey-opt)
-for setting up positional and optional arguments to commands).  The
-`handler` is an async function that's invoked when the command is
-executed and it's passed the parsed command line arguments and a
-reference to the `Control` class of clusterioctl.  It's possible to optain
-a reference to the plugin class with `control.plugins.get(info.name)`.
+For a command the `definition` is the arguments to pass to [yargs.command](http://yargs.js.org/docs/#api-reference-commandcmd-desc-builder-handler) (see also [yargs.positional](http://yargs.js.org/docs/#api-reference-positionalkey-opt) and [yargs.options](http://yargs.js.org/docs/#api-reference-optionskey-opt) for setting up positional and optional arguments to commands).
+The `handler` is an async function that's invoked when the command is executed and it's passed the parsed command line arguments and a reference to the `Control` class of clusterioctl.
+It's possible to optain a reference to the plugin class with `control.plugins.get(info.name)`.
 
-Note that messages sent from clusterioctl needs to have
-`"control-master"` as a part of the links array for it to be accepted by
-the master server, see [Defining Link Messages](#defining-link-messages)
-for how to define the messages that can be sent to the master.
+Note that messages sent from clusterioctl needs to have `"control-master"` as a part of the links array for it to be accepted by the master server, see [Defining Link Messages](#defining-link-messages) for how to define the messages that can be sent to the master.
 
-To have the command tree become part of clusterioctl it needs to be added
-to the rootCommand tree in `addCommands` callback of the Control plugin:
+To have the command tree become part of clusterioctl it needs to be added to the rootCommand tree in `addCommands` callback of the Control plugin:
 
     const libPlugin = require("@clusterio/lib/plugin");
 

--- a/packages/ctl/README.md
+++ b/packages/ctl/README.md
@@ -1,70 +1,57 @@
-Clusterio Command Line Interface
-================================
+# Clusterio Command Line Interface
+
 
 Provides a command line interface for managing a Clusterio cluster.
 
-Note that this document only describes the options and commands for
-managing clusterioctl itself, see [Managing a
-cluster](/docs/managing-a-cluster.md) for the available commands used
-for managing a cluster.
+Note that this document only describes the options and commands for managing clusterioctl itself, see [Managing a cluster](/docs/managing-a-cluster.md) for the available commands used for managing a cluster.
 
 
-Usage
------
+## Usage
 
     npx clusterioctl <command>
 
 Common options:
 
- * `--plugin-list <file>` JSON file to use for storing the list of
-   plugins that are available to ctl.  Defaults to `plugin-list.json`
-   and will be created if it does not exist. See the `plugin` command
-   for managing this list.
+ * `--plugin-list <file>` JSON file to use for storing the list of plugins that are available to ctl.
+   Defaults to `plugin-list.json` and will be created if it does not exist.
+   See the `plugin` command for managing this list.
 
- * `--config <file>` JSON file to use for storing configuration for
-   ctl.  Defaults to `config-control.json` and will be created if it
-   does not exist.  See the `config` command for inspecting and
-   modifying the configuration.
+ * `--config <file>` JSON file to use for storing configuration for ctl.
+   Defaults to `config-control.json` and will be created if it does not exist.
+   See the `config` command for inspecting and modifying the configuration.
 
 
 ### `plugin <command>`
 
-Configure plugins available to be loaded by ctl.  The available plugins
-will be automatically loaded and the commands they provide will be added
-to the ctl utility.
+Configure plugins available to be loaded by ctl.
+The available plugins will be automatically loaded and the commands they provide will be added to the ctl utility.
 
 
 #### `plugin add <path>`
 
-Add plugin either by require path or relative/absolute path to the
-plugin directory.  A relative path must start with ./ or ../ (or .\ and
-..\ on Windows) otherwise it will be assumed to be a require path for an
-installed package in node_modules.
+Add plugin either by require path or relative/absolute path to the plugin directory.
+A relative path must start with ./ or ../ (or .\ and ..\ on Windows) otherwise it will be assumed to be a require path for an installed package in node_modules.
 
 For example, installing the Subspace Storage plugin:
 
     npm install @clusterio/plugin-subspace_storage
     npx clusterioctl plugin add @clusterio/plugin-subspace_storage
 
-Since the `plugin-list.json` is shared between master, slave and ctl you
-usually only need to do this once per machine.
+Since the `plugin-list.json` is shared between master, slave and ctl you usually only need to do this once per machine.
 
 
 #### `plugin remove <name>`
 
-Remove a plugin by its name.  This should be done before uninstalling
-the plugin, otherwise there will be an error when Clusterio tries to
-load the info from the plugin.  Removing and unistalling a plugin is
-usually not neccessary as the functions provided by the plugin can be
-disabled in the config.
+Remove a plugin by its name.
+This should be done before uninstalling the plugin, otherwise there will be an error when Clusterio tries to load the info from the plugin.
+Removing and unistalling a plugin is usually not neccessary as the functions provided by the plugin can be disabled in the config.
 
 For example, uninstalling the Subspace Storage plugin:
 
     npx clusterioctl plugin remove subspace_storage
     npm uninstall @clusterio/plugin-subspace_storage
 
-Since the `plugin-list.json` is shared between master, slave and ctl you
-usually only need to do this once per machine.
+Since the `plugin-list.json` is shared between master, slave and ctl you usually only need to do this once per machine.
 
 
 #### `plugin list`
@@ -74,18 +61,17 @@ Lists the plugins set up to be available by name followed by path.
 
 ### `config-control`
 
-Manage the ctl configuration.  This allows setting the url and token to
-the master server to manage.
+Manage the ctl configuration.
+This allows setting the url and token to the master server to manage.
 
 
 #### `config-control set <config-entry> [value]`
 
-Set a config entry to the given value.  If value is not provided the
-entry is set to null.  If the config entry is of type object the value
-must be a valid JSON serialization of an object.
+Set a config entry to the given value.
+If value is not provided the entry is set to null.
+If the config entry is of type object the value must be a valid JSON serialization of an object.
 
-See docs/configuration.md in the main repositiory for the available
-configuration.
+See docs/configuration.md in the main repositiory for the available configuration.
 
 
 #### `config-control show <config-entry>`
@@ -100,9 +86,6 @@ Lists up all configuration entries with their currently configured values.
 
 ## See Also
 
-[Managing a cluster](/docs/managing-a-cluster.md) for the available
-commands used for managing a cluster.
+[Managing a cluster](/docs/managing-a-cluster.md) for the available commands used for managing a cluster.
 
-[The Clusterio
-repository](https://github.com/clusterio/factorioClusterio)
-for instructions on how to set up a cluster.
+[The Clusterio repository](https://github.com/clusterio/factorioClusterio) for instructions on how to set up a cluster.

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -1,8 +1,5 @@
-Common Library for Clusterio
-============================
+# Common Library for Clusterio
 
-This package contains functionality shared between master, slave, ctl
-and/or plugins of Clusterio.
+This package contains functionality shared between master, slave, ctl and/or plugins of Clusterio.
 
-See [the Clusterio repository](https://github.com/clusterio/factorioClusterio)
-for more information on Clusterio.
+See [the Clusterio repository](https://github.com/clusterio/factorioClusterio) for more information on Clusterio.

--- a/packages/master/README.md
+++ b/packages/master/README.md
@@ -1,68 +1,55 @@
-Clusterio Master Server
-=======================
+# Clusterio Master Server
 
-Communication hub for Clusterio clusters.  The master server forwards
-data between Clusterio slaves connected to it and allows the cluster to
-be remotely managed through WebSocket connections to it either by using
-the included web interface or the Clusterio ctl command line utility.
+Communication hub for Clusterio clusters.
+The master server forwards data between Clusterio slaves connected to it and allows the cluster to be remotely managed through WebSocket connections to it either by using the included web interface or the Clusterio ctl command line utility.
 
 
-Usage
------
+# Usage
 
     npx clusteriomaster <command>
 
 Common options:
 
- * `--plugin-list <file>` JSON file to use for storing the list of
-   plugins that are available to the master server.  Defaults to
-   `plugin-list.json` and will be created if it does not exist. See the
-   `plugin` command for managing this list.
+ * `--plugin-list <file>` JSON file to use for storing the list of plugins that are available to the master server.
+   Defaults to `plugin-list.json` and will be created if it does not exist.
+   See the `plugin` command for managing this list.
 
- * `--config <file>` JSON file to use for storing configuration for the
-   master server.  Defaults to `config-master.json` and will be created
-   if it does not exist.  See the `config` command for inspecting and
-   modifying the configuration.
+ * `--config <file>` JSON file to use for storing configuration for the master server.
+   Defaults to `config-master.json` and will be created if it does not exist.
+   See the `config` command for inspecting and modifying the configuration.
 
 
 ### `plugin <command>`
 
-Configure plugins available to be loaded by the master server.  The
-available plugins will be loaded unless they have been disabled in the
-configuration, see the config command for disabling plugins.
+Configure plugins available to be loaded by the master server.
+The available plugins will be loaded unless they have been disabled in the configuration, see the config command for disabling plugins.
 
 
 #### `plugin add <path>`
 
-Add plugin either by require path or relative/absolute path to the
-plugin directory.  A relative path must start with ./ or ../ (or .\ and
-..\ on Windows) otherwise it will be assumed to be a require path for an
-installed package in node_modules.
+Add plugin either by require path or relative/absolute path to the plugin directory.
+A relative path must start with ./ or ../ (or .\ and ..\ on Windows) otherwise it will be assumed to be a require path for an installed package in node_modules.
 
 For example, installing the Subspace Storage plugin:
 
     npm install @clusterio/plugin-subspace_storage
     npx clusteriomaster plugin add @clusterio/plugin-subspace_storage
 
-Since the `plugin-list.json` is shared between master, slave and ctl you
-usually only need to do this once per machine.
+Since the `plugin-list.json` is shared between master, slave and ctl you usually only need to do this once per machine.
 
 
 #### `plugin remove <name>`
 
-Remove a plugin by its name.  This should be done before uninstalling
-the plugin, otherwise there will be an error when Clusterio tries to
-load the info from the plugin.  Removing and unistalling a plugin is
-usually not neccessary as the functions provided by the plugin can be
-disabled in the config.
+Remove a plugin by its name.
+This should be done before uninstalling the plugin, otherwise there will be an error when Clusterio tries to load the info from the plugin.
+Removing and unistalling a plugin is usually not neccessary as the functions provided by the plugin can be disabled in the config.
 
 For example, uninstalling the Subspace Storage plugin:
 
     npx clusteriomaster plugin remove subspace_storage
     npm uninstall @clusterio/plugin-subspace_storage
 
-Since the `plugin-list.json` is shared between master, slave and ctl you
-usually only need to do this once per machine.
+Since the `plugin-list.json` is shared between master, slave and ctl you usually only need to do this once per machine.
 
 
 #### `plugin list`
@@ -72,20 +59,17 @@ Lists the plugins set up to be available by name followed by path.
 
 ### `config`
 
-Manage the master server configuration offline.  This should only be
-used when the master server is stopped, otherwise the config read might
-be out of date and config changes will be overwritten when the master
-server shuts down.
+Manage the master server configuration offline.
+This should only be used when the master server is stopped, otherwise the config read might be out of date and config changes will be overwritten when the master server shuts down.
 
 
 #### `config set <config-entry> [value]`
 
-Set a config entry to the given value.  If value is not provided the
-entry is set to null.  If the config entry is of type object the value
-must be a valid JSON serialization of an object.
+Set a config entry to the given value.
+If value is not provided the entry is set to null.
+If the config entry is of type object the value must be a valid JSON serialization of an object.
 
-See docs/configuration.md in the main repositiory for the available
-configuration entries.
+See docs/configuration.md in the main repositiory for the available configuration entries.
 
 
 #### `config show <config-entry>`
@@ -105,22 +89,19 @@ Commands for setting up initial admin acount and access to the cluster.
 
 #### `bootstrap create-admin <name>`
 
-Creates a new user account with the given name if it does not already
-exist in the cluster and grant it full cluster admin permission.  You
-should be using your own Factorio multiplayer username here.
+Creates a new user account with the given name if it does not already exist in the cluster and grant it full cluster admin permission.
+You should be using your own Factorio multiplayer username here.
 
 
 #### `bootstrap generate-user-token <name>`
 
-Generate an access token for logging in and possibly managing the
-cluster from the given user account.  This can be used both in the web
-interface and as the `master_token` to connect with clusterioctl.
+Generate an access token for logging in and possibly managing the cluster from the given user account.
+This can be used both in the web interface and as the `master_token` to connect with clusterioctl.
 
 
 #### `bootstrap create-ctl-config <name>`
 
-Creates a clusterioctl config for the given user with url and token set
-up for connecting to the cluster.
+Creates a clusterioctl config for the given user with url and token set up for connecting to the cluster.
 
 
 ### `run`
@@ -130,6 +111,4 @@ Runs the master server.
 
 ## See Also
 
-[The Clusterio
-repository](https://github.com/clusterio/factorioClusterio)
-for instructions on how to set up a cluster.
+[The Clusterio repository](https://github.com/clusterio/factorioClusterio) for instructions on how to set up a cluster.

--- a/packages/slave/README.md
+++ b/packages/slave/README.md
@@ -1,70 +1,56 @@
-Clusterio Slave
-===============
+# Clusterio Slave
 
-Node hosting Factorio servers in a Clusterio cluster.  Clusterio slaves
-connect to the master server and waits for commands from the master
-server to start up and stop instances.  A cluster can have any number of
-slaves in it located on different computers, and each slave can host any
-number of instances each of which is a Factorio server that talks with
-the rest of the cluster.
+Node hosting Factorio servers in a Clusterio cluster.
+Clusterio slaves connect to the master server and waits for commands from the master server to start up and stop instances.
+A cluster can have any number of slaves in it located on different computers, and each slave can host any number of instances each of which is a Factorio server that talks with the rest of the cluster.
 
 
-Usage
------
+## Usage
 
     npx clusterioslave <command>
 
 Common options:
 
- * `--plugin-list <file>` JSON file to use for storing the list of
-   plugins that are available to the slave.  Defaults to
-   `plugin-list.json` and will be created if it does not exist. See the
-   `plugin` command for managing this list.
+ * `--plugin-list <file>` JSON file to use for storing the list of plugins that are available to the slave.
+   Defaults to `plugin-list.json` and will be created if it does not exist.
+   See the `plugin` command for managing this list.
 
- * `--config <file>` JSON file to use for storing configuration for the
-   slave.  Defaults to `config-slave.json` and will be created if it
-   does not exist.  See the `config` command for inspecting and
-   modifying the configuration.
+ * `--config <file>` JSON file to use for storing configuration for the slave.
+   Defaults to `config-slave.json` and will be created if it does not exist.
+   See the `config` command for inspecting and modifying the configuration.
 
 
 ### `plugin <command>`
 
-Configure plugins available to be loaded by the slave.  The available
-plugins will be loaded unless they have been disabled in the
-configuration, see the config command for disabling plugins.
+Configure plugins available to be loaded by the slave.
+The available plugins will be loaded unless they have been disabled in the configuration, see the config command for disabling plugins.
 
 
 #### `plugin add <path>`
 
-Add plugin either by require path or relative/absolute path to the
-plugin directory.  A relative path must start with ./ or ../ (or .\ and
-..\ on Windows) otherwise it will be assumed to be a require path for an
-installed package in node_modules.
+Add plugin either by require path or relative/absolute path to the plugin directory.
+A relative path must start with ./ or ../ (or .\ and ..\ on Windows) otherwise it will be assumed to be a require path for an installed package in node_modules.
 
 For example, installing the Subspace Storage plugin:
 
     npm install @clusterio/plugin-subspace_storage
     npx clusterioslave plugin add @clusterio/plugin-subspace_storage
 
-Since the `plugin-list.json` is shared between master, slave and ctl you
-usually only need to do this once per machine.
+Since the `plugin-list.json` is shared between master, slave and ctl you usually only need to do this once per machine.
 
 
 #### `plugin remove <name>`
 
-Remove a plugin by its name.  This should be done before uninstalling
-the plugin, otherwise there will be an error when Clusterio tries to
-load the info from the plugin.  Removing and unistalling a plugin is
-usually not neccessary as the functions provided by the plugin can be
-disabled in the config.
+Remove a plugin by its name.
+This should be done before uninstalling the plugin, otherwise there will be an error when Clusterio tries to load the info from the plugin.
+Removing and unistalling a plugin is usually not neccessary as the functions provided by the plugin can be disabled in the config.
 
 For example, uninstalling the Subspace Storage plugin:
 
     npx clusterioslave plugin remove subspace_storage
     npm uninstall @clusterio/plugin-subspace_storage
 
-Since the `plugin-list.json` is shared between master, slave and ctl you
-usually only need to do this once per machine.
+Since the `plugin-list.json` is shared between master, slave and ctl you usually only need to do this once per machine.
 
 
 #### `plugin list`
@@ -74,19 +60,17 @@ Lists the plugins set up to be available by name followed by path.
 
 ### `config`
 
-Manage the slave configuration offline.  This should only be used when
-the slave is stopped, otherwise the config read might be out of date and
-config changes will be overwritten when the slave shuts down.
+Manage the slave configuration offline.
+This should only be used when the slave is stopped, otherwise the config read might be out of date and config changes will be overwritten when the slave shuts down.
 
 
 #### `config set <config-entry> [value]`
 
-Set a config entry to the given value.  If value is not provided the
-entry is set to null.  If the config entry is of type object the value
-must be a valid JSON serialization of an object.
+Set a config entry to the given value.
+If value is not provided the entry is set to null.
+If the config entry is of type object the value must be a valid JSON serialization of an object.
 
-See docs/configuration.md in the main repositiory for the available
-configuration.
+See docs/configuration.md in the main repositiory for the available configuration.
 
 
 #### `config show <config-entry>`
@@ -106,6 +90,4 @@ Runs the slave.
 
 ## See Also
 
-[The Clusterio
-repository](https://github.com/clusterio/factorioClusterio)
-for instructions on how to set up a cluster.
+[The Clusterio repository](https://github.com/clusterio/factorioClusterio) for instructions on how to set up a cluster.

--- a/plugins/global_chat/README.md
+++ b/plugins/global_chat/README.md
@@ -1,16 +1,13 @@
-Clusterio Global Chat Plugin
-============================
+# Clusterio Global Chat Plugin
 
 Plugin sharing the in-game chat between instances.
 
 
-Installation
-============
+## Installation
 
 Run the following commands in the folder Clusterio is installed to:
 
     npm install @clusterio/plugin-global_chat
     npx clusteriomaster plugin add @clusterio/plugin-global_chat
 
-Substitute clusteriomaster with clusterioslave or clusterioctl if this a
-dedicate slave or ctl installation respectively.
+Substitute clusteriomaster with clusterioslave or clusterioctl if this a dedicate slave or ctl installation respectively.

--- a/plugins/player_auth/README.md
+++ b/plugins/player_auth/README.md
@@ -1,42 +1,31 @@
-Clusterio Player Auth Plugin
-============================
+# Clusterio Player Auth Plugin
 
 Plugin authenticating logged in players to the web interface.
-Authentication is achieved by a simple challenge response mechanism
-where players have to log into one of the Factorio server in the cluster
-and open a dialog that presents a code, this code is input into the
-login form on the web interface which gives back a second code.  Once
-the player enters the second code into the dialog in-game the web
-interface is authenticated.
+Authentication is achieved by a simple challenge response mechanism where players have to log into one of the Factorio server in the cluster and open a dialog that presents a code, this code is input into the login form on the web interface which gives back a second code.
+Once the player enters the second code into the dialog in-game the web interface is authenticated.
 
 
-Installation
-------------
+## Installation
 
 Run the following commands in the folder Clusterio is installed to:
 
     npm install @clusterio/plugin-player_auth
     npx clusteriomaster plugin add @clusterio/plugin-player_auth
 
-Substitute clusteriomaster with clusterioslave or clusterioctl if this a
-dedicate slave or ctl installation respectively.
+Substitute clusteriomaster with clusterioslave or clusterioctl if this a dedicate slave or ctl installation respectively.
 
 
-Master Configuration
---------------------
+## Master Configuration
 
 #### player_auth.code_length
 
-Length in character of the generated challenge codes that need to be
-input between the web interface login form and the in-game Factorio
-login dialog.
+Length in character of the generated challenge codes that need to be input between the web interface login form and the in-game Factorio login dialog.
 
 Defaults to `6`.
 
 #### player_auth.code_timeout
 
-Time in seconds the first code generated stays valid.  The login must be
-completed in less than this time starting from when the login dialog is
-opened in-game.
+Time in seconds the first code generated stays valid.
+The login must be completed in less than this time starting from when the login dialog is opened in-game.
 
 Defaults to `120`.

--- a/plugins/research_sync/README.md
+++ b/plugins/research_sync/README.md
@@ -1,17 +1,13 @@
-Clusterio Research Sync Plugin
-==============================
+# Clusterio Research Sync Plugin
 
-Plugin synchronizing research progress between instances and the
-cluster.
+Plugin synchronizing research progress between instances and the cluster.
 
 
-Installation
-============
+## Installation
 
 Run the following commands in the folder Clusterio is installed to:
 
     npm install @clusterio/plugin-research_sync
     npx clusteriomaster plugin add @clusterio/plugin-research_sync
 
-Substitute clusteriomaster with clusterioslave or clusterioctl if this a
-dedicate slave or ctl installation respectively.
+Substitute clusteriomaster with clusterioslave or clusterioctl if this a dedicate slave or ctl installation respectively.

--- a/plugins/statistics_exporter/README.md
+++ b/plugins/statistics_exporter/README.md
@@ -1,33 +1,24 @@
-Clusterio Statistics Exporter Plugin
-====================================
+# Clusterio Statistics Exporter Plugin
 
-Plugin exporting item production, fluid production, kill count, entity
-build and pollution statistics to the Prometheus integration to
-Clusterio.
+Plugin exporting item production, fluid production, kill count, entity build and pollution statistics to the Prometheus integration to Clusterio.
 
 
-Installation
-------------
+## Installation
 
 Run the following commands in the folder Clusterio is installed to:
 
     npm install @clusterio/plugin-statistics_exporter
     npx clusteriomaster plugin add @clusterio/plugin-statistics_exporter
 
-Substitute clusteriomaster with clusterioslave or clusterioctl if this a
-dedicate slave or ctl installation respectively.
+Substitute clusteriomaster with clusterioslave or clusterioctl if this a dedicate slave or ctl installation respectively.
 
 
-Instance Configuration
-----------------------
+## Instance Configuration
 
 ### statistics_exporter.command_timeout
 
-Timeout in seconds to wait for the statitics gathering command to the
-Factorio server return the result.  If the timeout is exceeded the
-previous collected results are returned instead.  Normally the command
-returns immediatly with the data, but if the RCON interface is
-overloaded then the command may take too long to timely answer the
-metrics collection request.
+Timeout in seconds to wait for the statitics gathering command to the Factorio server return the result.
+If the timeout is exceeded the previous collected results are returned instead.
+Normally the command returns immediatly with the data, but if the RCON interface is overloaded then the command may take too long to timely answer the metrics collection request.
 
 Defaults to `1`.

--- a/plugins/subspace_storage/README.md
+++ b/plugins/subspace_storage/README.md
@@ -1,16 +1,13 @@
-Clusterio Subspace Storage Plugin
-=================================
+# Clusterio Subspace Storage Plugin
 
 Plugin for the Subpsace Storage mod.
 
 
-Installation
-============
+## Installation
 
 Run the following commands in the folder Clusterio is installed to:
 
     npm install @clusterio/plugin-subspace_storage
     npx clusteriomaster plugin add @clusterio/plugin-subspace_storage
 
-Substitute clusteriomaster with clusterioslave or clusterioctl if this a
-dedicate slave or ctl installation respectively.
+Substitute clusteriomaster with clusterioslave or clusterioctl if this a dedicate slave or ctl installation respectively.


### PR DESCRIPTION
Simplify the the way markdown files are formatted to make them easier to author without editors that do auto line breaking, and make the diffs from them simpler to read.

---

This is something I've thought about for some time now. Basically having markdown files that look pretty to read makes them more difficult to edit and makes the diffs harder to read. So the idea here is make the format easy to edit and author and stop caring about the source looking pretty.