### PR TITLE
Drop support for Node.js v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 10
+  - 12
 before_install:
   - curl -o factorio.tar.gz -L https://www.factorio.com/get-download/latest/headless/linux64
   - tar -xf factorio.tar.gz

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Check out the documentation on [Writing Plugins](/docs/writing-plugins.md) for w
 
 **Warning**: These instructions are for the unstable master version and is not recommended for use, see [the 1.2.x branch][1.2.x] for how to install the stable version.
 
-Clusterio runs on Node.js v12 and up, and v10.16.0+.
+Clusterio runs on Node.js v12 and up.
 Node.js itself is not supported on EOL Ubuntu releases so make sure you're on a recent release of Ubuntu.
 
 Master and all slaves:
@@ -136,7 +136,7 @@ Your instances (save files etc) will be stored there.
 **Requirements**
 
 download and install nodeJS 12 from http://nodejs.org.
-Clusterio runs on Node.js v12 and up, and v10.16.0+.
+Clusterio runs on Node.js v12 and up.
 
 **Master**
 
@@ -169,8 +169,8 @@ Clusterio runs on Node.js v12 and up, and v10.16.0+.
 
 **Requirements**
 
-download and install nodeJS 12 from http://nodejs.org or brew (`brew install node`).  Clusterio runs on Node.js v12 and
-up, and v10.16.0+.
+Download and install nodeJS 12 from http://nodejs.org or brew (`brew install node`).
+Clusterio runs on Node.js v12 and up.
 
 1. Open Terminal or Command prompt in the directory you want to install to and run the following commands.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -150,8 +150,8 @@ The format of this log should be self explanatory, please follow it carefully.
 
 ## Supported Node.js and Factorio Versions
 
-Clusterio run on Node.js v12 and up, and v10 from v10.16.0, make sure to check that the Node builtin API's and npm packages you use are supported on these versions.
-The Travis CI tests are runned on whatever version of Node.js v10 is the default, which at the time of writing is v10.18.0.
+Clusterio run on Node.js v12 and up, make sure to check that the Node builtin API's and npm packages you use are supported on these versions.
+The Travis CI tests are runned on whatever version of Node.js v12 is the default.
 
 For Factorio Clusterio 2.0 aims to support version 0.17.69 and up, including the latest experimental release.
 It's recommended that you use the lua API reference for 0.17.69, as there's no information on what version Factorio API's were introduced in.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     ]
   },
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "devDependencies": {
     "eslint": "^7.25.0",

--- a/packages/ctl/package.json
+++ b/packages/ctl/package.json
@@ -15,7 +15,7 @@
     "factorio"
   ],
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "dependencies": {
     "@clusterio/lib": "^2.0.0-alpha.5",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -8,7 +8,7 @@
     "factorio"
   ],
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "dependencies": {
     "ajv": "^6.12.6",

--- a/packages/master/package.json
+++ b/packages/master/package.json
@@ -16,7 +16,7 @@
     "factorio"
   ],
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "dependencies": {
     "@clusterio/lib": "^2.0.0-alpha.5",

--- a/packages/slave/package.json
+++ b/packages/slave/package.json
@@ -15,7 +15,7 @@
     "factorio"
   ],
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "dependencies": {
     "@clusterio/lib": "^2.0.0-alpha.5",

--- a/packages/web_ui/package.json
+++ b/packages/web_ui/package.json
@@ -12,7 +12,7 @@
     "clusterio"
   ],
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "dependencies": {
     "@ant-design/icons": "^4.2.2",

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/clusterio/factorioClusterio/issues"
   },
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "peerDependencies": {
     "@clusterio/lib": "^2.0.0-alpha.0"

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/clusterio/factorioClusterio/issues"
   },
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "peerDependencies": {
     "@clusterio/lib": "^2.0.0-alpha.0"

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/clusterio/factorioClusterio/issues"
   },
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "peerDependencies": {
     "@clusterio/lib": "^2.0.0-alpha.0"

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/clusterio/factorioClusterio/issues"
   },
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "peerDependencies": {
     "@clusterio/lib": "^2.0.0-alpha.0"

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/clusterio/factorioClusterio/issues"
   },
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "peerDependencies": {
     "@clusterio/lib": "^2.0.0-alpha.0"

--- a/test/package.json
+++ b/test/package.json
@@ -2,7 +2,7 @@
   "name": "test",
   "private": true,
   "engines": {
-    "node": ">=10.16 <11 || >= 12"
+    "node": ">=12"
   },
   "dependencies": {
     "@clusterio/ctl": "2.0.0-alpha.5",


### PR DESCRIPTION
Version 10 of Node.js is no longer supported upstream, so stop supporting running Clusterio with it.