### PR TITLE
Add slave update subscriptions

### DIFF
--- a/packages/ctl/ctl.js
+++ b/packages/ctl/ctl.js
@@ -918,6 +918,8 @@ class Control extends libLink.Link {
 		this.keepOpen = false;
 	}
 
+	async slaveUpdateEventHandler() { }
+
 	async instanceUpdateEventHandler() { }
 
 	async saveListUpdateEventHandler() { }

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -331,6 +331,14 @@ messages.setMasterConfigProp = new Request({
 	},
 });
 
+let slaveProperties = {
+	"agent": { type: "string" },
+	"version": { type: "string" },
+	"name": { type: "string" },
+	"id": { type: "integer" },
+	"connected": { type: "boolean" },
+};
+
 messages.listSlaves = new Request({
 	type: "list_slaves",
 	links: ["control-master"],
@@ -341,14 +349,21 @@ messages.listSlaves = new Request({
 			items: {
 				additionalProperties: false,
 				required: ["agent", "version", "name", "id", "connected"],
-				properties: {
-					"agent": { type: "string" },
-					"version": { type: "string" },
-					"name": { type: "string" },
-					"id": { type: "integer" },
-					"connected": { type: "boolean" },
-				},
+				properties: slaveProperties,
 			},
+		},
+	},
+});
+
+messages.setSlaveSubscriptions = new Request({
+	type: "set_slave_subscriptions",
+	links: ["control-master"],
+	permission: "core.slave.subscribe",
+	requestProperties: {
+		"all": { type: "boolean" },
+		"slave_ids": {
+			type: "array",
+			items: { type: "integer" },
 		},
 	},
 });
@@ -1082,6 +1097,13 @@ messages.logMessage = new Event({
 		},
 	},
 });
+
+messages.slaveUpdate = new Event({
+	type: "slave_update",
+	links: ["master-control"],
+	eventProperties: slaveProperties,
+});
+
 
 messages.instanceInitialized = new Event({
 	type: "instance_initialized",

--- a/packages/lib/users.js
+++ b/packages/lib/users.js
@@ -323,6 +323,12 @@ definePermission({
 	grantByDefault: true,
 });
 definePermission({
+	name: "core.slave.subscribe",
+	title: "Subscribe to slave updates",
+	description: "Subscribe to be notified on updates on the details of slaves.",
+	grantByDefault: true,
+});
+definePermission({
 	name: "core.slave.generate_token",
 	title: "Generate slave token",
 	description: "Generate tokens for slaves to connect to the cluster with.",

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -39,6 +39,11 @@ class ControlConnection extends BaseConnection {
 		 */
 		this.user = user;
 
+		this.slaveSubscriptions = {
+			all: false,
+			slave_ids: [],
+		};
+
 		this.instanceSubscriptions = {
 			all: false,
 			instance_ids: [],
@@ -105,6 +110,19 @@ class ControlConnection extends BaseConnection {
 			});
 		}
 		return { list };
+	}
+
+	async setSlaveSubscriptionsRequestHandler(message) {
+		this.slaveSubscriptions = message.data;
+	}
+
+	slaveUpdated(slave, update) {
+		if (
+			this.slaveSubscriptions.all
+			|| this.slaveSubscriptions.slave_ids.includes(slave.id)
+		) {
+			libLink.messages.slaveUpdate.send(this, update);
+		}
 	}
 
 	generateSlaveToken(slaveId) {

--- a/packages/master/src/Master.js
+++ b/packages/master/src/Master.js
@@ -360,6 +360,24 @@ class Master {
 		}
 	}
 
+	slaveUpdated(slave) {
+		let update = {
+			agent: slave.agent,
+			version: slave.version,
+			id: slave.id,
+			name: slave.name,
+			connected: this.wsServer.slaveConnections.has(slave.id),
+		};
+
+		for (let controlConnection of this.wsServer.controlConnections) {
+			if (controlConnection.connector.closing) {
+				continue;
+			}
+
+			controlConnection.slaveUpdated(slave, update);
+		}
+	}
+
 	addInstanceHooks(instance) {
 		instance.config.on("fieldChanged", (group, field, prev) => {
 			if (group.name === "instance" && field === "name") {

--- a/packages/master/src/WsServer.js
+++ b/packages/master/src/WsServer.js
@@ -274,9 +274,11 @@ ${err.stack}`
 			connector.on("close", () => {
 				if (this.slaveConnections.get(data.id) === connection) {
 					this.slaveConnections.delete(data.id);
+					this.master.slaveUpdated(this.master.slaves.get(data.id));
 				}
 			});
 			this.slaveConnections.set(data.id, connection);
+			this.master.slaveUpdated(this.master.slaves.get(data.id));
 
 
 		} else if (type === "register_control") {

--- a/packages/web_ui/src/components/AssignInstanceModal.jsx
+++ b/packages/web_ui/src/components/AssignInstanceModal.jsx
@@ -5,24 +5,20 @@ import libLink from "@clusterio/lib/link";
 
 import ControlContext from "./ControlContext";
 import { notifyErrorHandler } from "../util/notify";
+import { useSlaveList } from "../model/slave";
 
 const { Paragraph } = Typography;
 
 
 export default function AssignInstanceModal(props) {
 	let [visible, setVisible] = useState(false);
-	let [slaves, setSlaves] = useState([]);
-	let [loading, setLoading] = useState(true);
+	let [slaveList] = useSlaveList();
 	let [applying, setApplying] = useState(false);
 	let [form] = Form.useForm();
 	let control = useContext(ControlContext);
 
 	function open() {
 		setVisible(true);
-		libLink.messages.listSlaves.send(control).then((result) => {
-			setSlaves(result.list);
-			setLoading(false);
-		});
 	}
 
 	function handleAssign() {
@@ -73,8 +69,8 @@ export default function AssignInstanceModal(props) {
 			</Paragraph>
 			<Form form={form} initialValues={{ slave: props.slaveId }}>
 				<Form.Item name="slave" label="Slave">
-					<Select loading={loading}>
-						{slaves.map((slave) => <Select.Option
+					<Select>
+						{slaveList.map((slave) => <Select.Option
 							key={slave["id"]}
 							value={slave["id"]}
 							disabled={!slave["connected"]}

--- a/packages/web_ui/src/components/SlavesPage.jsx
+++ b/packages/web_ui/src/components/SlavesPage.jsx
@@ -1,28 +1,42 @@
 import React, { useContext } from "react";
+import { Table } from "antd";
 
 import libLink from "@clusterio/lib/link";
 
-import DataTable from "./data-table";
 import ControlContext from "./ControlContext";
 import PageLayout from "./PageLayout";
+import { useSlaveList } from "../model/slave";
 
 
 export default function SlavesPage() {
 	let control = useContext(ControlContext);
-
-	async function listSlaves() {
-		let result = await libLink.messages.listSlaves.send(control);
-		return result["list"].map((item) => ({
-			key: item["id"],
-			"Name": item["name"],
-			"Agent": item["agent"],
-			"Version": item["version"],
-			"Connected": item["connected"] && "Yes",
-		}));
-	}
+	let [slaveList] = useSlaveList();
 
 	return <PageLayout nav={[{ name: "Slaves" }]}>
 		<h2>Slaves</h2>
-		<DataTable DataFunction={listSlaves} />
+		<Table
+			columns={[
+				{
+					title: "Name",
+					dataIndex: "name",
+				},
+				{
+					title: "Agent",
+					dataIndex: "agent",
+				},
+				{
+					title: "Version",
+					dataIndex: "version",
+				},
+				{
+					title: "Connected",
+					key: "connected",
+					render: slave => slave["connected"] && "Yes",
+				},
+			]}
+			dataSource={slaveList}
+			rowKey={slave => slave["id"]}
+			pagination={false}
+		/>
 	</PageLayout>;
 };

--- a/packages/web_ui/src/model/slave.jsx
+++ b/packages/web_ui/src/model/slave.jsx
@@ -27,7 +27,52 @@ export function useSlave(id) {
 
 	useEffect(() => {
 		updateSlave();
+
+		function updateHandler(newSlave) {
+			setSlave({ ...newSlave, present: true });
+		}
+
+		control.onSlaveUpdate(id, updateHandler);
+		return () => {
+			control.offSlaveUpdate(id, updateHandler);
+		};
 	}, [id]);
 
 	return [slave, updateSlave];
+}
+
+export function useSlaveList() {
+	let control = useContext(ControlContext);
+	let [slaveList, setSlaveList] = useState([]);
+
+	function updateSlaveList() {
+		libLink.messages.listSlaves.send(control).then(result => {
+			setSlaveList(result.list);
+		});
+	}
+
+	useEffect(() => {
+		updateSlaveList();
+
+		function updateHandler(newSlave) {
+			setSlaveList(oldList => {
+				let newList = oldList.concat();
+				let index = newList.findIndex(s => s.id === newSlave.id);
+				if (index !== -1) {
+					newList[index] = newSlave;
+				} else {
+					newList.push(newSlave);
+				}
+				return newList;
+			});
+		}
+
+		control.onSlaveUpdate(null, updateHandler);
+		return () => {
+			control.offSlaveUpdate(null, updateHandler);
+		};
+	}, []);
+
+
+	return [slaveList];
 }

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -25,10 +25,14 @@ class TestControl extends libLink.Link {
 	constructor(connector) {
 		super("control", "master", connector);
 		libLink.attachAllMessages(this);
+		this.slaveUpdates = [];
 		this.instanceUpdates = [];
 		this.saveListUpdates = [];
 
 		this.connector.on("connect", () => {
+			libLink.messages.setSlaveSubscriptions.send(
+				this, { all: true, slave_ids: [] }
+			).catch(err => logger.error(`Error setting slave subscriptions:\n${err.stack}`));
 			libLink.messages.setInstanceSubscriptions.send(
 				this, { all: true, instance_ids: [] }
 			).catch(err => logger.error(`Error setting instance subscriptions:\n${err.stack}`));
@@ -44,6 +48,10 @@ class TestControl extends libLink.Link {
 	}
 
 	async debugWsMessageEventHandler() { }
+
+	async slaveUpdateEventHandler(message) {
+		this.slaveUpdates.push(message.data);
+	}
 
 	async instanceUpdateEventHandler(message) {
 		this.instanceUpdates.push(message.data);
@@ -223,6 +231,7 @@ module.exports = {
 	execCtl,
 	sendRcon,
 	getControl,
+	spawn,
 
 	url,
 	controlToken,


### PR DESCRIPTION
Allow the web interface to listen for updates to the slave list and apply it live to the places where slaves are shown in the web interface.

This is a working implementation of what #355 set out to do.