### PR TITLE
Fix tests on Windows and remove internet requirement to pass

### DIFF
--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -123,10 +123,18 @@ describe("Integration of Clusterio", function() {
 
 		describe("instance create", function() {
 			it("creates the instance", async function() {
+				this.timeout(6000);
 				await execCtl("instance create test --id 44");
 				let instances = await getInstances();
 				assert(instances.has(44), "instance was not created");
 				assert.equal(instances.get(44).status, "unassigned", "incorrect instance status");
+
+				// Make sure the following tests does not fail due to not having internet
+				let value = JSON.stringify({ lan: true, public: false }).replace(
+					/"/g, process.platform === "win32" ? '""' : '\\"'
+				);
+				await execCtl(`instance config set-prop test factorio.settings visibility "'${value}'"`);
+				await execCtl("instance config set-prop test factorio.settings require_user_verification false");
 			});
 		});
 

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -103,6 +103,12 @@ describe("Integration of lib/factorio/server", function() {
 				slowTest(this);
 				log(".start()");
 
+				// Make sure the test does not fail due to not having internet
+				let settings = await server.exampleSettings();
+				settings.visibility = { public: false, lan: true };
+				settings.require_user_verification = false;
+				await fs.outputFile(server.writePath("server-settings.json"), JSON.stringify(settings, null, 4));
+
 				// Make sure the test does not fail due to create() failing.
 				let mapPath = server.writePath("saves", "test.zip");
 				assert(await fs.exists(mapPath), "save is missing");

--- a/test/master/HttpCloser.js
+++ b/test/master/HttpCloser.js
@@ -144,6 +144,7 @@ function serverSuite(proto) {
 	});
 
 	it("should refuse connection if request sent after starting closure", async function() {
+		this.timeout(4000); // On Windows this test takes 2 seconds for some reason.
 		server.on("request", (request, response) => {
 			setTimeout(() => { response.end("ok-4"); }, 3*tick);
 		});


### PR DESCRIPTION
Fix for HttpCloser test on Windows and the requirement of having internet to for the tests to pass.