### PR TITLE
Remove suggestion to use the 1.2.x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,10 @@ Discord for development/support/play: https://discord.gg/5XuDkje
 
 ## Important notice
 
-This is the development branch for factorioClusterio 2.0 which is currently undergoing heavy restructuring and refactoring.
-Expect plugins and existing installations to frequently break when using this branch.
-If you don't want to be an alpha tester for 2.0 please use the stable [1.2.x branch][1.2.x] or [latest stable release](https://github.com/clusterio/factorioClusterio/releases/latest).
+Clusterio 2.0 is still in alpha, however the previous stable has been abandoned and is no longer supported.
+Despite being alpha it's reasonably stable now and there's no major breakages expected before a stable release of 2.0.
+If you are starting a new cluster it's highly recommended to use the 2.0 alpha.
 
-Installation instructions below are for the unstable master branch.
-Go to the page for the [1.2.x branch][1.2.x] for instructions on how to install the stable version.
-
-[1.2.x]: https://github.com/clusterio/factorioClusterio/tree/1.2.x
 
 ### Ways to support me/the project:
 
@@ -100,8 +96,6 @@ Otherwise see below for OS specific instructions.
 
 ### Ubuntu setup
 
-**Warning**: These instructions are for the unstable master version and is not recommended for use, see [the 1.2.x branch][1.2.x] for how to install the stable version.
-
 1.  Install Node.js v12 or higher.
     For 20.04 LTS or below the version of Node.js provided by the Ubuntu repos are too old and you will have to use the nodesource PPA, otherwise you may skip the first line.
 
@@ -145,8 +139,6 @@ Your instances (save files etc) will be stored there.
 -->
 
 ### Windows setup
-
-**Warning**: These instructions are for the unstable master version and is not recommended for use, see [the 1.2.x branch][1.2.x] for how to install the stable version.
 
 1.  Download and install the latest LTS release from http://nodejs.org.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,8 +93,8 @@ Note that webpack is configured to delete the web interface build when using the
 ### Starting a Feature Branch
 
 Development is done exclusively in feature branches.
-This means the first thing to do before starting any development at all is to make a new branch starting from the master or 1.2.x branch of the main repository.
-To do this check out that branch from the main repository (substitute master for 1.2.x if you're working on that branch).
+This means the first thing to do before starting any development at all is to make a new branch starting from the master branch of the main repository.
+To do this check out that branch from the main repository.
 
     git fetch upstream
     git checkout upstream/master
@@ -135,7 +135,7 @@ If there are more changes you want to have merged or mistakes you need to fix yo
 
 Until your feature branch is merged you can edit it as you see fit by using the rebase tool.
 If your feature branch has been merged however it's final and you will have to start a new feature branch and submit that in a new pull request.
-The base usage of rebase assuming you are checked out on your feature branch is the following command (substitute master with 1.2.x if your feature branch is based on that)
+The base usage of rebase assuming you are checked out on your feature branch is the following command
 
     git rebase -i upstream/master
 
@@ -154,7 +154,7 @@ If you have a pull request that has not yet been merged submitted for this featu
 ### Resolving Merge Conflicts
 
 The best way to resolve merge conflicts in feature braches is to rebase it on top of the updated upstream.
-Run the following commands (substitute master with 1.2.x if your feature branch is based on that)
+Run the following commands
 
     git fetch upstream
     git rebase upstream/master


### PR DESCRIPTION
Development on 1.2.x has effectively been abandoned, this is part two of #393 which removes the suggestion to use 1.2.x from the master branch.